### PR TITLE
Chore/conditional rendering

### DIFF
--- a/src/components/RealTimeInterface/SessionImageCapture.vue
+++ b/src/components/RealTimeInterface/SessionImageCapture.vue
@@ -10,6 +10,7 @@ const selectedFilter = ref('')
 
 const aladinRef = ref(null)
 
+// TO DO: add more conditions where we check for ranges and valid values
 const allFieldsFilled = computed(() => {
   const filled = exposureTime.value.trim() !== '' && exposureCount.value.trim() !== '' && selectedFilter.value.trim() !== ''
   emits('update:renderGallery', filled)

--- a/src/components/RealTimeInterface/SessionImageCapture.vue
+++ b/src/components/RealTimeInterface/SessionImageCapture.vue
@@ -1,6 +1,8 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, defineEmits, computed, watch } from 'vue'
 import AladinSkyMap from './AladinSkyMap.vue'
+
+const emits = defineEmits(['update:renderGallery'])
 
 const exposureTime = ref('')
 const exposureCount = ref('')
@@ -8,11 +10,21 @@ const selectedFilter = ref('')
 
 const aladinRef = ref(null)
 
+const allFieldsFilled = computed(() => {
+  const filled = exposureTime.value.trim() !== '' && exposureCount.value.trim() !== '' && selectedFilter.value.trim() !== ''
+  emits('update:renderGallery', filled)
+  return filled
+})
+
 function changeFov (fov) {
   if (aladinRef.value && aladinRef.value.setFov) {
     aladinRef.value.setFov(fov)
   }
 }
+
+watch([exposureTime, exposureCount, selectedFilter], () => {
+  emits('update:renderGallery', allFieldsFilled.value)
+})
 
 </script>
 

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -16,6 +16,8 @@ let timeRemainingInterval
 const moveTelescope = ref(false)
 const captureImages = ref(false)
 
+const renderGallery = ref(false)
+
 onMounted(() => {
   timeRemainingInterval = setInterval(() => {
     timeRemaining.value--
@@ -53,8 +55,8 @@ function goToLocation () {
     <v-btn :disabled="ra === '' || dec === ''" color="indigo" @click="moveTelescope = true">MOVE TELESCOPE</v-btn>
   </div>
   <div v-else-if="moveTelescope === true && captureImages === false">
-    <SessionImageCapture />
-    <v-btn class="go-button" color="indigo" @click="captureImages = true">GO</v-btn>
+    <SessionImageCapture @update:renderGallery="renderGallery = $event"/>
+    <v-btn class="go-button" color="indigo" @click="captureImages = true" :disabled="!renderGallery" >GO</v-btn>
   </div>
   <div v-else-if="captureImages === true">
     <RealTimeGallery />


### PR DESCRIPTION
## CHORE: Added conditional rendering so that users cannot press 'Go' if `Exposure Time`, `Exposure Count`, or `Filter` are left blank

**Background:**
We want to implement as many checkpoints as possible to reduce room for error so that kids don't waste their RTI time. Disabling buttons when essential fields are empty is a good blocker : ) 

**Implementation:**
Added a computed function in `SessionImageCapture` that updates an emits to true when all three fields are filled out. Then this is emitted in the parent component and enables the Go button.

### VISUALS
**Screen recording of Go button going from disabled to enabled** 

https://github.com/LCOGT/lco-education-platform/assets/54489472/1d4b7844-ab2f-4040-83a1-c36a9b02b263

