### PR TITLE
fixed header display

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,20 +3,14 @@ import { ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import AboutView from './components/Views/AboutView.vue'
-import HomeView from './components/Views/HomeView.vue'
 
 const showNavTabs = ref(false)
-const homeIsVisible = ref(true)
 const route = useRoute()
 const router = useRouter()
 
 function handleObserveClick () {
   showNavTabs.value = true
   router.push('/dashboard')
-}
-
-function closeHomeView () {
-  homeIsVisible.value = false
 }
 
 watch(
@@ -84,7 +78,6 @@ watch(
         </div>
       </div>
     </section>
-    <HomeView v-if="homeIsVisible" @close="closeHomeView"/>
     <router-view/>
   </div>
 </template>

--- a/src/components/Views/DashboardView.vue
+++ b/src/components/Views/DashboardView.vue
@@ -1,11 +1,21 @@
 <script setup>
 import MyGallery from '../Images/MyGallery.vue'
 import UpcomingBookings from '../Dashboard/UpcomingBookings.vue'
+import HomeView from '../Views/HomeView.vue'
+import { ref } from 'vue'
 
+const homeIsVisible = ref(true)
+
+function closeHomeView () {
+  homeIsVisible.value = false
+}
 </script>
 
 <template>
     <div class="container">
+        <div v-if="homeIsVisible">
+            <HomeView @close="closeHomeView"/>
+        </div>
         <div class="columns">
             <div class="column is-three-fifths">
                 <MyGallery />


### PR DESCRIPTION
## QUICK FIX: Dashboard header display

**Background:**
It makes sense to have the two buttons (i.e. Remote control a telescope and Schedule an observation) above the dashboard as a header and only there. This PR fixes that


https://github.com/LCOGT/lco-education-platform/assets/54489472/b9a8d25e-1e48-4455-9e6c-d4897d9cafe2

