### PR TITLE
fixes skymap's settings

### DIFF
--- a/src/components/RealTimeInterface/CelestialMap/SkyChart.vue
+++ b/src/components/RealTimeInterface/CelestialMap/SkyChart.vue
@@ -7,17 +7,6 @@ const Celestial = celestial.Celestial ? celestial.Celestial() : celestial
 const lat = ref(35)
 const lng = ref(-105)
 const hours_offset = ref(0)
-// const timezone = 'America/Denver'
-
-// function getOffset (timeZone = 'UTC', date = new Date()) {
-//   const utcDate = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' }))
-//   const tzDate = new Date(date.toLocaleString('en-US', { timeZone }))
-//   return (tzDate - utcDate) / 60000
-// }
-
-// function now () {
-//   Celestial.date(new Date())
-// }
 
 function updateLocation () {
   const time = new Date()
@@ -30,15 +19,12 @@ function updateLocation () {
 onMounted(() => {
   const config = {
     width: 500,
-    projection: 'stereographic', // Map projection used: airy, aitoff, armadillo, august, azimuthalEqualArea, azimuthalEquidistant, baker, berghaus, boggs, bonne, bromley, collignon, craig, craster, cylindricalEqualArea, cylindricalStereographic, eckert1, eckert2, eckert3, eckert4, eckert5, eckert6, eisenlohr, equirectangular, fahey, foucaut, ginzburg4, ginzburg5, ginzburg6, ginzburg8, ginzburg9, gringorten, hammer, hatano, healpix, hill, homolosine, kavrayskiy7, lagrange, larrivee, laskowski, loximuthal, mercator, miller, mollweide, mtFlatPolarParabolic, mtFlatPolarQuartic, mtFlatPolarSinusoidal, naturalEarth, nellHammer, orthographic, patterson, polyconic, rectangularPolyconic, robinson, sinusoidal, stereographic, times, twoPointEquidistant, vanDerGrinten, vanDerGrinten2, vanDerGrinten3, vanDerGrinten4, wagner4, wagner6, wagner7, wiechel, winkel3
-    transform: 'equatorial', // Coordinate transformation: equatorial (default), ecliptic, galactic, supergalactic
-    controls: false, // zoom controls
-
-    // geopos: [this.lat, this.lng],
+    projection: 'stereographic',
+    transform: 'equatorial',
+    controls: false,
     orientationfixed: true,
     follow: 'zenith',
     disableAnimations: true,
-
     stars: {
       show: true,
       size: 6,
@@ -67,15 +53,13 @@ onMounted(() => {
         'ura',
         'nep'
       ],
-      // Font styles for planetary symbols
       symbolType: 'disk',
       symbols: {
-        // Character and color for each symbol in 'which', simple circle \u25cf
         sol: { symbol: '\u2609', letter: 'Su', fill: '#ffff00', size: '24' },
         mer: { symbol: '\u263f', letter: 'Me', fill: '#cccccc' },
         ven: { symbol: '\u2640', letter: 'V', fill: '#eeeecc' },
         ter: { symbol: '\u2295', letter: 'T', fill: '#00ccff' },
-        lun: { symbol: '\u25cf', letter: 'L', fill: '#ffffff', size: '24' }, // overridden by generated crecent, except letter & size
+        lun: { symbol: '\u25cf', letter: 'L', fill: '#ffffff', size: '24' },
         mar: { symbol: '\u2642', letter: 'Ma', fill: '#ff6600' },
         cer: { symbol: '\u26b3', letter: 'C', fill: '#cccccc' },
         ves: { symbol: '\u26b6', letter: 'Ma', fill: '#cccccc' },
@@ -94,6 +78,26 @@ onMounted(() => {
         baseline: 'top'
       },
       namesType: 'desig'
+    },
+    constellations: {
+      show: false,
+      names: false,
+      namesType: false,
+      nameStyle: {
+        fill: '#cccc99',
+        align: 'center',
+        baseline: 'middle',
+        opacity: 0.8,
+        font: [
+          'bold 14px Helvetica, Arial, sans-serif',
+          'bold 12px Helvetica, Arial, sans-serif',
+          'bold 11px Helvetica, Arial, sans-serif'
+        ]
+      },
+      lines: false,
+      lineStyle: { stroke: '#cccccc', width: 1, opacity: 0.6 },
+      bounds: false,
+      boundStyle: { stroke: '#cccc00', width: 0.5, opacity: 0.8, dash: [2, 4] }
     }
   }
 
@@ -103,19 +107,12 @@ onMounted(() => {
 </script>
 
 <template>
-    <div id="celestial-map"></div>
-    <!-- <input label="lng" type="number" v-model.number="lng" />
-    <input label="lat" type="number" v-model.number="lat" />
-    <input label="+ hours" type="number" v-model.number="hours_offset" />
-    <button @click="updateLocation">go</button>
-    <button @click="now">now</button>
-    <div>{{ [lat, lng] }}</div>
-    <div>{{ getOffset(timezone) }}</div> -->
-  </template>
+  <div id="celestial-map"></div>
+</template>
 
 <style scoped>
-  #celestial-map {
-    width: 100%;
-    height: 31.25em;
-  }
+#celestial-map {
+  width: 100%;
+  height: 31.25em;
+}
 </style>


### PR DESCRIPTION
## QUICK FIX: Getting rid of excessive noise in skymap

**Background:**
We want to have only the necessary settings for skymap to avoid noise and distraction.

**Implementation:**
Added 
```
    constellations: {
      show: false,
      names: false,
      namesType: false,
      nameStyle: {
        fill: '#cccc99',
        align: 'center',
        baseline: 'middle',
        opacity: 0.8,
        font: [
          'bold 14px Helvetica, Arial, sans-serif',
          'bold 12px Helvetica, Arial, sans-serif',
          'bold 11px Helvetica, Arial, sans-serif'
        ]
      },
      lines: false,
      lineStyle: { stroke: '#cccccc', width: 1, opacity: 0.6 },
      bounds: false,
      boundStyle: { stroke: '#cccc00', width: 0.5, opacity: 0.8, dash: [2, 4] }
    }
```
to stop constellations from rendering 

### VISUALS

**Screenshot of new skymap**


![Screenshot 2024-05-14 at 12 14 44 PM](https://github.com/LCOGT/lco-education-platform/assets/54489472/04367d96-2006-49ad-8538-e7559e428025)


