### PR TITLE
Store/sessions

### DIFF
--- a/src/components/RealTimeInterface/GlobeMap/LeafletMap.vue
+++ b/src/components/RealTimeInterface/GlobeMap/LeafletMap.vue
@@ -1,14 +1,15 @@
 <script setup>
-import { ref, onMounted, defineEmits } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useSessionsStore } from '../../../stores/sessions'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import availableIcon from '../../../assets/Icons/available_mapmarker.png'
 import unavailableIcon from '../../../assets/Icons/unavailable_mapmarker.png'
 
+const sessionsStore = useSessionsStore()
+
 const mapMarkerAvailable = availableIcon
 const mapMarkerUnavailable = unavailableIcon
-
-const emits = defineEmits(['siteSelected'])
 
 const mapContainer = ref(null)
 
@@ -34,7 +35,6 @@ onMounted(() => {
     popupAnchor: [0, -42]
   })
 
-  // TO DO: Get actual locations
   const locations = [
     { lat: 34.4208, lng: -119.6982, site: 'Santa Barbara, California' },
     { lat: 35.0844, lng: -106.6504, site: 'Albuquerque, New Mexico' },
@@ -42,7 +42,6 @@ onMounted(() => {
     { lat: -37.8136, lng: 144.9631, site: 'Melbourne, Australia' }
   ]
 
-  // TO DO: Check availability of each site depending on time and date
   locations.forEach(location => {
     const available = isAvailable()
     const icon = available ? customIconAvailable : customIconUnavailable
@@ -52,7 +51,7 @@ onMounted(() => {
     marker.bindPopup(popupText)
     marker.on('click', () => {
       if (available) {
-        emits('siteSelected', { site: location.site, lat: location.lat, lon: location.lng })
+        sessionsStore.selectedSite = { site: location.site, lat: location.lat, lon: location.lng }
       }
     })
     marker.addTo(map)
@@ -61,15 +60,12 @@ onMounted(() => {
 </script>
 
 <template>
-    <div>
-        <div ref="mapContainer" class="map-container"></div>
-    </div>
+  <div ref="mapContainer" class="map-container"></div>
 </template>
 
 <style>
 .map-container {
   height: 80vh;
   width: 100%;
-  scale: 0.8;
 }
 </style>

--- a/src/components/RealTimeInterface/TimePicker.vue
+++ b/src/components/RealTimeInterface/TimePicker.vue
@@ -31,7 +31,6 @@ const resetSession = () => {
 
 const bookDate = () => {
   const selectedSite = sessionsStore.selectedSite
-  console.log('selected site,', selectedSite)
   if (date.value && time.value && selectedSite) {
     const newSession = {
       date: date.value,

--- a/src/components/Views/RealTimeInterfaceView.vue
+++ b/src/components/Views/RealTimeInterfaceView.vue
@@ -1,21 +1,21 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { useSessionsStore } from '../../stores/sessions'
 import TimePicker from '../RealTimeInterface/TimePicker.vue'
 import SessionPending from '../RealTimeInterface/SessionPending.vue'
 import SessionStarted from '../RealTimeInterface/SessionStarted.vue'
 
+const sessionsStore = useSessionsStore()
+
 const currentView = ref('scheduling')
 const timeRemaining = ref(20)
-const selectedSiteLat = ref(null)
-const selectedSiteLon = ref(null)
+
+const latestSession = computed(() => {
+  return sessionsStore.sessions[sessionsStore.sessions.length - 1] || {}
+})
 
 const handleViewChange = (view) => {
   currentView.value = view
-}
-
-const handleSiteSelected = (data) => {
-  selectedSiteLat.value = data.lat
-  selectedSiteLon.value = data.lon
 }
 
 // TO DO: Instead of having a set time, get the actual length of the time
@@ -35,13 +35,12 @@ const countdown = setInterval(() => {
       <TimePicker
         v-if="currentView === 'scheduling'"
         @changeView="handleViewChange"
-        @siteSelected="handleSiteSelected"
       />
       <SessionPending
         v-else-if="currentView === 'sessionpending'"
         @changeView="handleViewChange"
-        :lat="selectedSiteLat"
-        :lon="selectedSiteLon"
+        :lat="latestSession.location.latitude"
+        :lon="latestSession.location.longitude"
       />
       <div v-else-if="currentView === 'sessionstarted'">
         <h2>Real Time Session</h2>

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ const pinia = createPinia()
 pinia.use(piniaPluginPersistedState)
 
 createApp(App)
-  .use(pinia)
   .use(router)
   .use(vuetify)
+  .use(pinia)
   .mount('#app')

--- a/src/stores/sessions.js
+++ b/src/stores/sessions.js
@@ -1,0 +1,24 @@
+import { defineStore } from 'pinia'
+
+export const useSessionsStore = defineStore('sessions', {
+  state () {
+    return {
+      sessions: [],
+      currentSessionId: null,
+      nextSessionId: 1
+    }
+  },
+  getters: {
+    currentSession (state) {
+      return state.sessions.find(session => session.id === state.currentSessionId) || {}
+    }
+  },
+  actions: {
+    addSession (session) {
+      const newSession = { ...session, id: this.nextSessionId }
+      this.sessions.push(newSession)
+      this.nextSessionId++
+      this.currentSessionId = newSession.id
+    }
+  }
+})

--- a/src/stores/sessions.js
+++ b/src/stores/sessions.js
@@ -5,7 +5,7 @@ export const useSessionsStore = defineStore('sessions', {
     return {
       sessions: [],
       currentSessionId: null,
-      nextSessionId: 1
+      nextSessionId: 0
     }
   },
   getters: {


### PR DESCRIPTION
## DEVELOPER FEATURE: Added Sessions Store 

**Background:**
There are certain values/fields that makes sense to have them persist rather than pass them as props or emits. In this PR, I've implemented a sessions store that stores the date, time, location, type (for now, it's always `'realtime'`. The `type` will allow for reusability when it comes to scheduling observations and accessing the same store), and an id as a new RTI session is created. I've also made the changes where it was obvious to access the store instead of passing props/emits.

**Implementation:**
I created a new folder called `stores` and inside it, is a file called `sessions.js`. This store could be deconstructed into smaller stores (e.g. `coordinates.js`) but I thought that perhaps that would be too small a store and for the time being, this seems like the right approach. 
The store is pretty concise. I initialize `sessions` as an empty array, `currentSessionId` is `null`, and `nextSessionId` starts as `1`. 
`currentSessionId` is meant to be used primarily for rendering purposes in `DashboardView` and when the user selects that session, render the data that relates to that session. Perhaps better nomenclature needs to take over this variable. Will think of one.
The `addSession` action is pretty simple but becomes more evident of what it does in the `TimePicker` and `LeafletMap` components. I'll go into the details of how it pushes a session in a moment. This action also adds one `nextSessionId` and `currentSessionId` is assigned the previous value of `nextSessionId`. This is so that each session's id is unique and ascending in order.


In the components, the changes were minimal. In `LeafletMap`, instead of using emits to assign latitude and longitude, we now assign the values to the store as `{ site: location.site, lat: location.lat, lon: location.lng }` and then these get modified/simplified in the `TimePicker` component.
In `TimePicker`, the function `bookDate` restructures the `selectedSite` value to be inside the `location` object as `latitude` and `longitude` and `date`, `time`, and `type` get pushed along `location` as a `newSession` to the `sessionsStore`. The `location` will become useful when syncing the `SkyMap` and `Aladin` and What's Up In The Sky. `site` (from the `LeafletMap` component) currently goes away because it doesn't serve a purpose now but it will when we want to render the upcoming bookings in the `DashboardView`. 

### VISUALS
**Screenshot of the store **
<img width="562" alt="Screenshot 2024-05-21 at 3 37 16 PM" src="https://github.com/LCOGT/lco-education-platform/assets/54489472/c5d9a4c3-f01c-448a-bc34-fae1d17da886">


