### PR TITLE
added logic to poll thumbnails but currently only display the first one

### DIFF
--- a/src/components/RealTimeInterface/PolledThumbnails.vue
+++ b/src/components/RealTimeInterface/PolledThumbnails.vue
@@ -1,0 +1,35 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const thumbnails = ref([])
+
+let pollingInterval = null
+
+const thumbnailsApiUrl = 'http://archive-api-dev.lco.gtn/thumbnails/?frame_basename=&proposal_id=&observation_id=617904267&request_id=&size=large'
+
+function getThumbnails () {
+  console.log('here')
+  fetch(thumbnailsApiUrl)
+    .then(response => response.json())
+    .then(data => {
+      console.log('this is data', data)
+      thumbnails.value = data.results.map(result => result.url)
+      console.log('this is thumbnails', thumbnails.value)
+    })
+    .catch(error => {
+      console.error('Error:', error)
+    })
+}
+
+onMounted(() => {
+  getThumbnails()
+  pollingInterval = setInterval(getThumbnails, 5000)
+})
+
+</script>
+
+<template>
+    <div>
+<img :src="thumbnails[0]" />
+</div>
+</template>

--- a/src/components/RealTimeInterface/PolledThumbnails.vue
+++ b/src/components/RealTimeInterface/PolledThumbnails.vue
@@ -8,13 +8,10 @@ let pollingInterval = null
 const thumbnailsApiUrl = 'http://archive-api-dev.lco.gtn/thumbnails/?frame_basename=&proposal_id=&observation_id=617904267&request_id=&size=large'
 
 function getThumbnails () {
-  console.log('here')
   fetch(thumbnailsApiUrl)
     .then(response => response.json())
     .then(data => {
-      console.log('this is data', data)
       thumbnails.value = data.results.map(result => result.url)
-      console.log('this is thumbnails', thumbnails.value)
     })
     .catch(error => {
       console.error('Error:', error)

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -5,6 +5,7 @@ import AladinSkyMap from '../RealTimeInterface/AladinSkyMap.vue'
 import SkyChart from '../RealTimeInterface/CelestialMap/SkyChart.vue'
 import SessionImageCapture from '../RealTimeInterface/SessionImageCapture.vue'
 import RealTimeGallery from '../RealTimeInterface/RealTimeGallery.vue'
+import PolledThumbnails from '../RealTimeInterface/PolledThumbnails.vue'
 
 const router = useRouter()
 const aladinRef = ref(null)
@@ -211,6 +212,7 @@ onUnmounted(() => {
           <p>Progress: {{ item.progress }}</p>
           </div>
         </div>
+        <PolledThumbnails />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## FEATURE: Polling the archive

**Background:**
When a user is in an RTI session, we want to poll from the archive to display the latest images from their session.

**Implementation:**
Created a new component called `PolledThumbnails` where I make the api call to get the thumbnails associated with the observation id `617904267`. Currently it's hard coded but soon this will change.
Then I'm just showing the first thumbnail (which this will also change in the near future)

### VISUALS
**Screenshot of the thumbnail**
<img width="1719" alt="Screenshot 2024-06-03 at 5 22 24 PM" src="https://github.com/LCOGT/lco-education-platform/assets/54489472/73bc721a-9d65-471c-affc-b9484b2da730">
