### PR TITLE
Fix/remove settings view

### DIFF
--- a/src/components/RealTimeInterface/AladinSkyMap.vue
+++ b/src/components/RealTimeInterface/AladinSkyMap.vue
@@ -2,13 +2,6 @@
 import { onMounted, ref, defineProps } from 'vue'
 import { initializeAladin } from '../../utils/aladinUtility.js'
 
-const props = defineProps({
-  targetname: {
-    type: String,
-    required: false
-  }
-})
-
 const aladinContainer = ref(null)
 let aladinInstance = null
 
@@ -16,7 +9,7 @@ onMounted(() => {
   initializeAladin(aladinContainer.value, {
     survey: 'P/DSS2/color',
     fov: 1,
-    target: props.targetname ? props.targetname : 'M33',
+    target: 'M33',
     cooFrame: 'ICRSd',
     showProjectionControl: false,
     showZoomControl: true,


### PR DESCRIPTION
## FIX: Remove settings from session image capture view 

**Background:**
A decision has been made and we may change our minds again. But we've now moved the exposure settings to the `SessionStarted` view and in `SessionImageCapture` view we only see the status of the telescope and poll the thumbnails from the archive

**Implementation:**
Got rid of duplicate exposure settings
Moved mosaic fov to `SessionStarted`
Removed emits and added props 

### VISUALS
**Screen recording of new view**

https://github.com/LCOGT/lco-education-platform/assets/54489472/651c5a4c-fa5b-4c97-8582-c7695ef39e80

