### PR TITLE
Fix/conditional settings

### DIFF
--- a/src/components/RealTimeInterface/CelestialMap/SkyChart.vue
+++ b/src/components/RealTimeInterface/CelestialMap/SkyChart.vue
@@ -139,7 +139,6 @@ onMounted(() => {
   }
 
   Celestial.display(config)
-  console.log('Celestial', Celestial.display(config))
   updateLocation()
 })
 </script>

--- a/src/components/RealTimeInterface/PolledThumbnails.vue
+++ b/src/components/RealTimeInterface/PolledThumbnails.vue
@@ -9,7 +9,6 @@ const randomNumber = ref(0)
 const thumbnailsApiUrl = 'http://archive-api-dev.lco.gtn/thumbnails/?frame_basename=&proposal_id=&observation_id=617904267&request_id=&size=large'
 
 function getThumbnails () {
-  console.log('Getting thumbnails')
   fetch(thumbnailsApiUrl)
     .then(response => response.json())
     .then(data => {

--- a/src/components/RealTimeInterface/PolledThumbnails.vue
+++ b/src/components/RealTimeInterface/PolledThumbnails.vue
@@ -9,6 +9,7 @@ const randomNumber = ref(0)
 const thumbnailsApiUrl = 'http://archive-api-dev.lco.gtn/thumbnails/?frame_basename=&proposal_id=&observation_id=617904267&request_id=&size=large'
 
 function getThumbnails () {
+  console.log('Getting thumbnails')
   fetch(thumbnailsApiUrl)
     .then(response => response.json())
     .then(data => {
@@ -22,7 +23,7 @@ function getThumbnails () {
 
 onMounted(() => {
   getThumbnails()
-  pollingInterval = setInterval(getThumbnails, 5000)
+  pollingInterval = setInterval(getThumbnails, 3000)
 })
 
 </script>

--- a/src/components/RealTimeInterface/SessionImageCapture.vue
+++ b/src/components/RealTimeInterface/SessionImageCapture.vue
@@ -34,10 +34,8 @@ const props = defineProps({
 })
 
 const status = ref(null)
-const renderThumbnail = ref(false)
 let pollingInterval = null
 
-const bridgeApiUrl = 'http://rti-bridge-dev.lco.gtn/command/go'
 const statusApiUrl = 'http://rti-bridge-dev.lco.gtn/status'
 
 async function fetchStatus () {
@@ -50,32 +48,32 @@ async function fetchStatus () {
   }
 }
 
-function commandGo () {
-  const requestBody = {
-    dec: props.dec,
-    expFilter: [props.selectedFilter, props.selectedFilter, props.selectedFilter],
-    expTime: [props.exposureTime, props.exposureTime, props.exposureTime],
-    name: 'test',
-    ra: props.ra
-  }
+// function commandGo () {
+//   const requestBody = {
+//     dec: props.dec,
+//     expFilter: [props.selectedFilter, props.selectedFilter, props.selectedFilter],
+//     expTime: [props.exposureTime, props.exposureTime, props.exposureTime],
+//     name: 'test',
+//     ra: props.ra
+//   }
 
-  fetch(bridgeApiUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify(requestBody)
-  })
-    .then(response => {
-      console.log('response', response)
-      if (response.ok) {
-        renderThumbnail.value = true
-      }
-    })
-    .catch(error => {
-      console.log('error', error)
-    })
-}
+//   fetch(bridgeApiUrl, {
+//     method: 'POST',
+//     headers: {
+//       'Content-Type': 'application/json'
+//     },
+//     body: JSON.stringify(requestBody)
+//   })
+//     .then(response => {
+//       console.log('response', response)
+//       if (response.ok) {
+//         renderThumbnail.value = true
+//       }
+//     })
+//     .catch(error => {
+//       console.log('error', error)
+//     })
+// }
 
 onMounted(() => {
   fetchStatus()
@@ -99,10 +97,7 @@ onUnmounted(() => {
                     <p>Progress: {{ item.progress }}</p>
                 </div>
             </div>
-            <v-btn class="go-button" color="indigo" @click="commandGo">Capture {{ props.targetName }}</v-btn>
-            <div v-if="renderThumbnail">
-                <PolledThumbnails />
-            </div>
+            <PolledThumbnails />
         </div>
     </div>
 </template>

--- a/src/components/RealTimeInterface/SessionImageCapture.vue
+++ b/src/components/RealTimeInterface/SessionImageCapture.vue
@@ -3,31 +3,7 @@ import { ref, defineProps, onMounted, onUnmounted } from 'vue'
 import PolledThumbnails from './PolledThumbnails.vue'
 
 const props = defineProps({
-  ra: {
-    type: Number,
-    required: true
-  },
-  dec: {
-    type: Number,
-    required: true
-  },
-  exposureCount: {
-    type: Number,
-    required: true
-  },
-  selectedFilter: {
-    type: String,
-    required: true
-  },
   exposureTime: {
-    type: Number,
-    required: true
-  },
-  targetName: {
-    type: String,
-    required: true
-  },
-  fieldOfView: {
     type: Number,
     required: true
   }
@@ -35,7 +11,8 @@ const props = defineProps({
 
 const status = ref(null)
 let pollingInterval = null
-
+// const countdown = ref(props.exposureTime)
+// let countdownInterval = null
 const statusApiUrl = 'http://rti-bridge-dev.lco.gtn/status'
 
 async function fetchStatus () {
@@ -48,36 +25,16 @@ async function fetchStatus () {
   }
 }
 
-// function commandGo () {
-//   const requestBody = {
-//     dec: props.dec,
-//     expFilter: [props.selectedFilter, props.selectedFilter, props.selectedFilter],
-//     expTime: [props.exposureTime, props.exposureTime, props.exposureTime],
-//     name: 'test',
-//     ra: props.ra
-//   }
-
-//   fetch(bridgeApiUrl, {
-//     method: 'POST',
-//     headers: {
-//       'Content-Type': 'application/json'
-//     },
-//     body: JSON.stringify(requestBody)
-//   })
-//     .then(response => {
-//       console.log('response', response)
-//       if (response.ok) {
-//         renderThumbnail.value = true
-//       }
-//     })
-//     .catch(error => {
-//       console.log('error', error)
-//     })
-// }
-
 onMounted(() => {
   fetchStatus()
   pollingInterval = setInterval(fetchStatus, 1000)
+  // countdownInterval = setInterval(() => {
+  //   if (countdown.value > 0) {
+  //     countdown.value--
+  //   } else {
+  //     clearInterval(countdownInterval)
+  //   }
+  // }, 1000)
 })
 
 onUnmounted(() => {
@@ -90,6 +47,7 @@ onUnmounted(() => {
     <div class="columns">
         <div class="column">
             <div v-if="status">
+              <!-- {{ countdown }} -->
                 <div v-for="item in status" :key="item">
                     <p>Observatory: {{ item.availability }}</p>
                     <p>Telescope: {{ item.telescope }}</p>

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import AladinSkyMap from '../RealTimeInterface/AladinSkyMap.vue'
@@ -16,6 +16,7 @@ const aladinRef = ref(null)
 const ra = ref('')
 const dec = ref('')
 const targetName = ref('')
+const validTarget = ref(false)
 const fieldOfView = ref(1.0)
 const progressBar = ref(0)
 const moveTelescope = ref(false)
@@ -30,6 +31,7 @@ const targetNameApiUrl = 'https://simbad2k.lco.global/'
 const bridgeApiUrl = 'http://rti-bridge-dev.lco.gtn/command/go'
 
 function getRaDecFromTargetName () {
+  validTarget.value = false
   fetch(`${targetNameApiUrl}${targetName.value}?target_type=sidereal`)
     .then(response => response.json())
     .then(data => {
@@ -45,8 +47,10 @@ function getRaDecFromTargetName () {
         if (vals[1] < 30.0) {
           targeterror.value = true
           targeterrorMsg.value = 'Target not visible. Try a different target.'
+          validTarget.value = false
         } else {
           targeterrorMsg.value = ''
+          validTarget.value = true
         }
         // Reset form fields when user looks up another target
         exposureTime.value = ''
@@ -86,7 +90,7 @@ function changeFov (fov) {
 }
 
 const allFieldsFilled = () => {
-  return ra.value && dec.value && exposureTime.value && exposureCount.value && selectedFilter.value
+  return ra.value && dec.value && exposureTime.value && exposureCount.value && selectedFilter.value && targetName.value && validTarget.value === true
 }
 
 function commandGo () {
@@ -113,6 +117,10 @@ function commandGo () {
       console.log('error', error)
     })
 }
+
+watch(targetName, () => {
+  validTarget.value = false
+})
 
 </script>
 <template>
@@ -159,7 +167,7 @@ function commandGo () {
             </div>
           </div>
         </div>
-        <div v-if="ra && dec && !targeterrorMsg">
+        <div v-if="ra && dec && !targeterrorMsg && targetName">
           <div class="columns">
                 <div class="column">
                   <p>Mosaic</p>

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -120,6 +120,8 @@ function commandGo () {
 
 watch(targetName, () => {
   validTarget.value = false
+  ra.value = ''
+  dec.value = ''
 })
 
 </script>

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -203,7 +203,9 @@ const allFieldsFilled = () => {
                 </div>
         </div>
         </div>
-        <button :disabled="!allFieldsFilled()" class="button red-bg" @click="moveTelescope = true">Capture <span v-if="allFieldsFilled()">{{ targetName }} </span></button>
+        <button :disabled="!allFieldsFilled()" class="button red-bg" @click="moveTelescope = true">
+          {{ allFieldsFilled() ? `Capture ${targetName}` : 'Capture' }}
+        </button>
         <div v-if="status">
         <div v-for="item in status" :key="item">
           <p>Observatory: {{ item.availability }}</p>
@@ -215,11 +217,6 @@ const allFieldsFilled = () => {
         <PolledThumbnails />
       </div>
     </div>
-  </div>
-  <div v-else-if="moveTelescope === true && captureImages === false">
-    <button :disabled="!allFieldsFilled()" class="button red-bg" @click="moveTelescope = true">
-      {{ allFieldsFilled() ? `Capture ${targetName}` : 'Capture' }}
-    </button>
   </div>
   <div v-else-if="captureImages === true && progressBar < 100">
     <RealTimeGallery @updateProgress="handleProgressUpdate" />

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -107,9 +107,7 @@ function commandGo () {
   })
     .then(response => {
       console.log('response', response)
-      if (response.ok) {
-        moveTelescope.value = true
-      }
+      moveTelescope.value = true
     })
     .catch(error => {
       console.log('error', error)
@@ -237,7 +235,7 @@ function commandGo () {
     </div>
   </div>
   <div v-else-if="moveTelescope === true && captureImages === false">
-    <SessionImageCapture :ra="ra" :dec="dec" :targetName="targetName" :exposureTime="exposureTime" :exposureCount="exposureCount" :selectedFilter="selectedFilter" />
+    <SessionImageCapture :exposure-time="exposureTime" />
   </div>
   <div v-else-if="captureImages === true && progressBar < 100">
     <RealTimeGallery @updateProgress="handleProgressUpdate" />

--- a/src/components/Views/RealTimeInterfaceView.vue
+++ b/src/components/Views/RealTimeInterfaceView.vue
@@ -9,10 +9,6 @@ const sessionsStore = useSessionsStore()
 const currentView = ref('sessionpending')
 const timeRemaining = ref(20)
 
-const latestSession = computed(() => {
-  return sessionsStore.sessions[sessionsStore.sessions.length - 1] || {}
-})
-
 const selectedSession = computed(() => {
   return sessionsStore.sessions.find(session => session.id === sessionsStore.currentSessionId)
 })

--- a/src/components/Views/RealTimeInterfaceView.vue
+++ b/src/components/Views/RealTimeInterfaceView.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { ref, computed } from 'vue'
 import { useSessionsStore } from '../../stores/sessions'
-import TimePicker from '../RealTimeInterface/TimePicker.vue'
 import SessionPending from '../RealTimeInterface/SessionPending.vue'
 import SessionStarted from '../RealTimeInterface/SessionStarted.vue'
 
@@ -36,10 +35,6 @@ const countdown = setInterval(() => {
 <template>
   <section>
     <div class="container">
-      <!-- <TimePicker
-        v-if="currentView === 'scheduling'"
-        @changeView="handleViewChange"
-      /> -->
       <SessionPending
         v-if="currentView === 'sessionpending'"
         @changeView="handleViewChange"


### PR DESCRIPTION
## FIX: Conditional rendering for exposure settings and validity of targets

**Background:**
We want the exposure settings to become visible only if a target is up in the sky or if it's a real target

**Implementation:**
Added conditional rendering so that exposure settings render only when there's no error message. 
Added a watcher so that if the user changes the target, the `capture target` button goes back to disabled and the ra and dec are empty strings --> hiding exposure settings.
I'm also resetting the values of the exposure settings to empty strings if the user selects another target. This can be easily undone if we want to save their exposure settings and just enter a new target.
Moved some code around that was repeated.
And added commented out code in case we want a countdown based on the exposure time.

### VISUALS
**Entering a valid target --> entering exposure settings --> button enabled --> deleting target --> button disabled and exposure settings hidden --> invalid target --> error message --> valid target --> enter exposure settings --> click button**

https://github.com/LCOGT/lco-education-platform/assets/54489472/55c1b204-f8b3-478e-8771-72bce6026039



