### PR TITLE
FIX: Conditional text and site name rendering

### DIFF
--- a/src/components/Dashboard/UpcomingBookings.vue
+++ b/src/components/Dashboard/UpcomingBookings.vue
@@ -31,17 +31,16 @@ const selectSession = (sessionId) => {
 </script>
 
 <template>
-    <button class="button red-bg" @click="redirectToBooking"> Book Slot </button>
     <div class="bookings">
-        <h3>Upcoming Bookings</h3>
+      <h3 v-if="allSessions.length">Upcoming Bookings</h3>
+      <h3 v-else>No Real-Time Sessions Booked</h3>
         <div class="table-summary">
         <div v-for="session in allSessions" :key="session.id">
             <div><a @click.prevent="selectSession(session.id)">{{ session.date }}</a></div><div>{{ session.time }}</div>
         </div>
         </div>
+        <button class="button red-bg" @click="redirectToBooking"> Book Slot </button>
     </div>
-    <button class="button red-bg" @click="redirectToScheduling">Schedule Observations</button>
-
     <div class="observations">
         <h3>Scheduled Observations</h3>
         <div class="table-summary">
@@ -49,6 +48,7 @@ const selectSession = (sessionId) => {
                 <div>{{ title }}</div><div><progress class="progress is-large is-primary" :value="progress" max="100">{{ progress }}%</progress></div>
             </div>
         </div>
+        <button class="button red-bg" @click="redirectToScheduling">Schedule Observations</button>
     </div>
 </template>
 


### PR DESCRIPTION
## FIX: Conditional rendering for bookings and added site name 

Quick change (that can be changed to something else but couldn't come up with any good phrases): If the user doesn't have anything booked, their dashboard reads "no real-time sessions booked" and if they do, then it reads "upcoming bookings".
Also moved the buttons below (hope that's okay) because it feels more intuitive
And now instead of reading "you are now controlling eltham college telescope" it reads "you are controlling the telescope in `selected site`"

### VISUALS
**Screenshot of "no real time sessions booked"**
<img width="1728" alt="Screenshot 2024-06-10 at 12 45 38 PM" src="https://github.com/LCOGT/lco-education-platform/assets/54489472/e4e0d51f-ff8b-44df-9451-285f741b5084">
**Screenshot of when a user has an upcoming booking**
<img width="1728" alt="Screenshot 2024-06-10 at 12 45 57 PM" src="https://github.com/LCOGT/lco-education-platform/assets/54489472/6a338c3d-0889-4a3b-b736-13fb785aaf55">
**Site name rendering**
<img width="1728" alt="Screenshot 2024-06-10 at 12 46 34 PM" src="https://github.com/LCOGT/lco-education-platform/assets/54489472/3bf00177-ef49-4f83-bf18-e70a2ae8f34c">

