### PR TITLE
Feature/block rti

### DIFF
--- a/src/components/Dashboard/UpcomingBookings.vue
+++ b/src/components/Dashboard/UpcomingBookings.vue
@@ -31,6 +31,12 @@ const selectSession = (sessionId) => {
   router.push(`/realtime/${sessionId}`)
 }
 
+const formatDate = (dateString) => {
+  const date = new Date(dateString)
+  const options = { year: 'numeric', month: 'long', day: 'numeric' }
+  return date.toLocaleDateString('en-US', options)
+}
+
 </script>
 
 <template>
@@ -39,7 +45,7 @@ const selectSession = (sessionId) => {
       <h3 v-else>No Real-Time Sessions Booked</h3>
         <div class="table-summary">
         <div v-for="session in sortedSessions" :key="session.id">
-            <div><a @click.prevent="selectSession(session.id)">{{ session.date }}</a></div><div>{{ session.time }}</div>
+            <div><a @click.prevent="selectSession(session.id)">{{ formatDate(session.date) }}</a></div><div>{{ session.time }}</div>
         </div>
         </div>
         <button class="button red-bg" @click="redirectToBooking"> Book Slot </button>

--- a/src/components/Dashboard/UpcomingBookings.vue
+++ b/src/components/Dashboard/UpcomingBookings.vue
@@ -39,7 +39,7 @@ const selectSession = (sessionId) => {
       <h3 v-else>No Real-Time Sessions Booked</h3>
         <div class="table-summary">
         <div v-for="session in sortedSessions" :key="session.id">
-            <div><a @click.prevent="selectSession(session.id)">{{ session.date.toDateString() }}</a></div><div>{{ session.time }}</div>
+            <div><a @click.prevent="selectSession(session.id)">{{ session.date }}</a></div><div>{{ session.time }}</div>
         </div>
         </div>
         <button class="button red-bg" @click="redirectToBooking"> Book Slot </button>

--- a/src/components/LogIn/LogIn.vue
+++ b/src/components/LogIn/LogIn.vue
@@ -14,7 +14,6 @@ const errorMessage = ref('')
 const apiUrl = 'http://observation-portal-dev.lco.gtn/api/'
 
 const storeToken = async (data) => {
-  console.log('storeToken', data)
   const authToken = data.token
   if (authToken) {
     userDataStore.authToken = authToken

--- a/src/components/LogIn/LogIn.vue
+++ b/src/components/LogIn/LogIn.vue
@@ -11,9 +11,10 @@ const username = ref('')
 const password = ref('')
 const errorMessage = ref('')
 
-const apiUrl = 'https://observe.lco.global/api/'
+const apiUrl = 'http://observation-portal-dev.lco.gtn/api/'
 
 const storeToken = async (data) => {
+  console.log('storeToken', data)
   const authToken = data.token
   if (authToken) {
     userDataStore.authToken = authToken

--- a/src/components/RealTimeInterface/CelestialMap/SkyChart.vue
+++ b/src/components/RealTimeInterface/CelestialMap/SkyChart.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted } from 'vue'
+import { useSessionsStore } from '../../../stores/sessions'
 import celestial from 'd3-celestial'
 
 const Celestial = celestial.Celestial ? celestial.Celestial() : celestial
@@ -17,6 +18,9 @@ function updateLocation () {
 }
 
 onMounted(() => {
+  const sessionsStore = useSessionsStore()
+  sessionsStore.prepareStore()
+
   const config = {
     width: 600,
     projection: 'stereographic',

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -49,7 +49,6 @@ function getRaDecFromTargetName () {
       } else {
         const lat = sessionsStore.selectedSite.lat
         const lon = sessionsStore.selectedSite.lon
-        console.log(lat, lon)
         ra.value = parseFloat(data.ra_d).toFixed(3)
         dec.value = parseFloat(data.dec_d).toFixed(3)
         const vals = calcAltAz(data.ra_d, data.dec_d, lat, lon)

--- a/src/components/RealTimeInterface/TimePicker.vue
+++ b/src/components/RealTimeInterface/TimePicker.vue
@@ -11,6 +11,7 @@ const sessionsStore = useSessionsStore()
 const date = ref(null)
 const startTime = ref(null)
 const endTime = ref(null)
+const errorMessage = ref(null)
 const emits = defineEmits(['changeView'])
 
 const toIsoDate = computed(() => {
@@ -26,15 +27,6 @@ const times = ['00:00', '00:15', '00:30', '00:45', '01:00', '01:15', '01:30', '0
 
 const selectTime = (selectedTime) => {
   startTime.value = selectedTime
-}
-
-const addMinutes = (time, minutesToAdd) => {
-  const [hours, minutes] = time.split(':')
-  const currentMinutes = parseInt(hours) * 60 + parseInt(minutes)
-  const newMinutes = currentMinutes + minutesToAdd
-  const newHours = Math.floor(newMinutes / 60)
-  const remainingMinutes = newMinutes % 60
-  return `${newHours.toString().padStart(2, '0')}:${remainingMinutes.toString().padStart(2, '0')}`
 }
 
 const setEndTime = (startDate, startTime, minutesToAdd) => {
@@ -61,6 +53,7 @@ const add15Minutes = () => {
 }
 
 const resetSession = () => {
+  errorMessage.value = null
   sessionsStore.selectedSite = null
   sessionsStore.currentSessionId = null
 }
@@ -79,6 +72,7 @@ const blockRti = async () => {
 }
 
 const handleError = (error) => {
+  errorMessage.value = 'Failed to book session. Please select another time'
   console.error('API call failed with error:', error)
 }
 
@@ -136,8 +130,9 @@ watch(startTime, (newTime, oldTime) => {
       </div>
       <div v-if="toIsoDate && startTime" class="column">
         <p class="selected-datetime">
-          <span v-if="sessionsStore.selectedSite">{{ sessionsStore.selectedSite.site }} Selected for {{ toIsoDate }} at {{ startTime }}</span>
-          <span v-else>Click on a pin to book for {{ toIsoDate }} at {{ startTime }}</span>
+          <span v-if="sessionsStore.selectedSite && !errorMessage">{{ sessionsStore.selectedSite.site }} Selected for {{ toIsoDate }} at {{ startTime }}</span>
+          <span v-else-if="!sessionsStore.selectedSite">Click on a pin to book for {{ toIsoDate }} at {{ startTime }}</span>
+          <span v-else-if="sessionsStore.selectedSite && errorMessage" class="error">{{ errorMessage }}</span>
         </p>
         <v-btn variant="tonal" v-if="date && sessionsStore.selectedSite" @click="bookDate" class="blue-bg">Book</v-btn>
       </div>
@@ -145,3 +140,9 @@ watch(startTime, (newTime, oldTime) => {
     </div>
   </div>
 </template>
+
+<style scoped>
+.error {
+  color: red;
+}
+</style>

--- a/src/components/RealTimeInterface/TimePicker.vue
+++ b/src/components/RealTimeInterface/TimePicker.vue
@@ -46,8 +46,8 @@ const blockRti = async () => {
     site: 'tst',
     enclosure: 'doma',
     telescope: '1m0a',
-    start: '2024-06-29T00:00:00Z',
-    end: '2024-06-29T00:30:00Z'
+    start: '2024-06-30T00:00:00Z',
+    end: '2024-06-30T00:30:00Z'
   }
   await fetchApiCall({ url: 'http://observation-portal-dev.lco.gtn/api/realtime/', method: 'POST', body: requestBody, successCallback: () => router.push('/dashboard'), failCallback: handleError })
 }

--- a/src/components/RealTimeInterface/TimePicker.vue
+++ b/src/components/RealTimeInterface/TimePicker.vue
@@ -59,6 +59,7 @@ const resetSession = () => {
 }
 
 const blockRti = async () => {
+  add15Minutes()
   const requestBody = {
     proposal: 'LCOSchedulerTest',
     name: 'Test Real Time',
@@ -68,7 +69,7 @@ const blockRti = async () => {
     start: formatToUTC(date.value, startTime.value),
     end: endTime.value
   }
-  await fetchApiCall({ url: 'http://observation-portal-dev.lco.gtn/api/realtime/', method: 'POST', body: requestBody, successCallback: () => router.push('/dashboard'), failCallback: handleError })
+  await fetchApiCall({ url: 'http://observation-portal-dev.lco.gtn/api/realtime/', method: 'POST', body: requestBody, successCallback: bookDate, failCallback: handleError })
 }
 
 const handleError = (error) => {
@@ -90,8 +91,7 @@ const bookDate = () => {
       type: 'realtime'
     }
     sessionsStore.addSession(newSession)
-    add15Minutes()
-    blockRti()
+    router.push('/dashboard')
   } else {
     alert('Please fill in all fields to book a session')
   }
@@ -134,7 +134,7 @@ watch(startTime, (newTime, oldTime) => {
           <span v-else-if="!sessionsStore.selectedSite">Click on a pin to book for {{ toIsoDate }} at {{ startTime }}</span>
           <span v-else-if="sessionsStore.selectedSite && errorMessage" class="error">{{ errorMessage }}</span>
         </p>
-        <v-btn variant="tonal" v-if="date && sessionsStore.selectedSite" @click="bookDate" class="blue-bg">Book</v-btn>
+        <v-btn variant="tonal" v-if="date && sessionsStore.selectedSite" @click="blockRti" class="blue-bg">Book</v-btn>
       </div>
       <LeafletMap v-if="toIsoDate && startTime" />
     </div>

--- a/src/components/RealTimeInterface/TimePicker.vue
+++ b/src/components/RealTimeInterface/TimePicker.vue
@@ -2,16 +2,21 @@
 import { ref, computed, watch, defineEmits } from 'vue'
 import { useRouter } from 'vue-router'
 import { useSessionsStore } from '../../stores/sessions'
+import { useUserDataStore } from '../../stores/userData'
+import { fetchApiCall } from '../../utils/api'
 import LeafletMap from './GlobeMap/LeafletMap.vue'
 
 const router = useRouter()
 const sessionsStore = useSessionsStore()
+const userDataStore = useUserDataStore()
+
+const apitoken = userDataStore.authToken
 
 const date = ref(null)
 const time = ref(null)
 const emits = defineEmits(['changeView'])
 
-const formattedDate = computed(() => {
+const toIsoDate = computed(() => {
   if (date.value) {
     const options = { year: 'numeric', month: 'long', day: 'numeric' }
     return date.value.toLocaleDateString('en-US', options)
@@ -31,6 +36,26 @@ const resetSession = () => {
   sessionsStore.currentSessionId = null
 }
 
+const blockRti = async () => {
+  // const selectedDate = new Date(date.value).toISOString().split('T')[0]
+  // const startDate = `${selectedDate}T${time.value}:00Z`
+  // const endDate = `${selectedDate}T${time.value}:50Z`
+  const requestBody = {
+    proposal: 'LCOSchedulerTest',
+    name: 'Test Real Time',
+    site: 'tst',
+    enclosure: 'doma',
+    telescope: '1m0a',
+    start: '2024-06-29T00:00:00Z',
+    end: '2024-06-29T00:30:00Z'
+  }
+  await fetchApiCall({ url: 'http://observation-portal-dev.lco.gtn/api/realtime/', method: 'POST', body: requestBody, successCallback: () => router.push('/dashboard'), failCallback: handleError })
+}
+
+const handleError = (error) => {
+  console.error('API call failed with error:', error)
+}
+
 const bookDate = () => {
   const selectedSite = sessionsStore.selectedSite
   if (date.value && time.value && selectedSite) {
@@ -45,7 +70,7 @@ const bookDate = () => {
       type: 'realtime'
     }
     sessionsStore.addSession(newSession)
-    router.push('/dashboard')
+    blockRti()
     // emits('changeView', 'sessionpending')
   } else {
     alert('Please fill in all fields to book a session')
@@ -83,14 +108,14 @@ watch(time, (newTime, oldTime) => {
           <v-btn v-for="time in times" :key="time" @click="selectTime(time)">{{ time }}</v-btn>
         </v-btn-group>
       </div>
-      <div v-if="formattedDate && time" class="column">
+      <div v-if="toIsoDate && time" class="column">
         <p class="selected-datetime">
-          <span v-if="sessionsStore.selectedSite">{{ sessionsStore.selectedSite.site }} Selected for {{ formattedDate }} at {{ time }}</span>
-          <span v-else>Click on a pin to book for {{ formattedDate }} at {{ time }}</span>
+          <span v-if="sessionsStore.selectedSite">{{ sessionsStore.selectedSite.site }} Selected for {{ toIsoDate }} at {{ time }}</span>
+          <span v-else>Click on a pin to book for {{ toIsoDate }} at {{ time }}</span>
         </p>
         <v-btn variant="tonal" v-if="date && sessionsStore.selectedSite" @click="bookDate" class="blue-bg">Book</v-btn>
       </div>
-      <LeafletMap v-if="formattedDate && time" />
+      <LeafletMap v-if="toIsoDate && time" />
     </div>
   </div>
 </template>

--- a/src/stores/sessions.js
+++ b/src/stores/sessions.js
@@ -23,6 +23,13 @@ export const useSessionsStore = defineStore('sessions', {
       this.sessions.push(newSession)
       this.nextSessionId++
       this.currentSessionId = newSession.id
+    },
+    prepareStore () {
+      this.sessions.forEach(session => {
+        if (session.date) {
+          session.date = new Date(session.date)
+        }
+      })
     }
   }
 })

--- a/src/stores/sessions.js
+++ b/src/stores/sessions.js
@@ -8,6 +8,7 @@ export const useSessionsStore = defineStore('sessions', {
       nextSessionId: 0
     }
   },
+  persist: true,
   getters: {
     currentSession (state) {
       return state.sessions.find(session => session.id === state.currentSessionId) || {}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -11,7 +11,6 @@ async function fetchApiCall ({ url, method, body = null, header, successCallback
   if (store.authToken) {
     defaultHeader.Authorization = `Token ${store.authToken}`
   }
-
   const config = {
     method,
     headers: header || defaultHeader,


### PR DESCRIPTION
## FEATURE: Block RTI sessions on `tst` site

**Background:**
To get even closer to the MVP, we have to block times on the RTI. 

**Implementation:**
A couple of things changed in order to be able to make a successful api call that would block time in the RTI.
First, I changed the api url for logging in. It's now the dev url because we need to store that token to be able to make a request to the rti dev api. 
I added persistence to the `sessions` store so that the `Upcoming Bookings` persist. But for some reason, this caused the `SkyChart` to return errors if the user refreshed the page. So, I added an action to the store that checks for the date and puts it in `Date` format. That prevents d3-celestial from returning errors.
I changed the times that the user can select so that the `tst` site is "available".
Lastly, to be able to make a POST request to the rti-dev api, there has to be a start time and an end time. To get the end time, I added a function that adds 15 minutes to the selected time. Right now, most of the request body is hard coded but the times aren't. This will be changed in the future.

### VISUALS
**Screen recording of selection of a time that has been blocked already by the RTI (though it doesn't show because I cleared my cookies) and then selecting a different date and successfully making the request to block that**

https://github.com/LCOGT/lco-education-platform/assets/54489472/7f9e4e70-0021-4246-b4de-84aa2604a5bd

