### PR TITLE
gets thumbnails from api and displays them on dashboard

### DIFF
--- a/src/components/Images/MyGallery.vue
+++ b/src/components/Images/MyGallery.vue
@@ -1,37 +1,86 @@
 <script setup>
-import thumbnail from '../../assets/TemporaryImages/thumbnail.png'
-import { computed } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 import { useSessionsStore } from '../../stores/sessions'
+import { useUserDataStore } from '../../stores/userData'
+import { useConfigurationStore } from '../../stores/configuration'
 import { formatDate } from '../../utils/formatTime.js'
+import { fetchApiCall } from '../../utils/api.js'
 
 const sessionsStore = useSessionsStore()
+const userDataStore = useUserDataStore()
+const configurationStore = useConfigurationStore()
 
-const observations = computed(() => {
+const thumbnailsMap = ref({})
+const loading = ref(true)
+
+const filteredSessions = computed(() => {
   const now = new Date()
-  // Current time minus 16 minutes
   const cutoffTime = new Date(now.getTime() - 16 * 60 * 1000)
-  if (sessionsStore.sessions.results) {
-    return sessionsStore.sessions.results
-      .filter(obs => new Date(obs.start) < cutoffTime)
-      .slice().sort((a, b) => {
-        return new Date(b.start) - new Date(a.start)
-      })
-  } else {
-    return []
-  }
+
+  const sessions = sessionsStore.sessions.results || []
+
+  return sessions
+    .filter(session => new Date(session.start) < cutoffTime)
+    .sort((a, b) => new Date(b.start) - new Date(a.start))
 })
 
+const getThumbnails = async (sessionId) => {
+  const token = userDataStore.authToken
+  const headers = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+    'Authorization': `Token ${token}`
+  }
+
+  await fetchApiCall({
+    url: configurationStore.thumbnailArchiveUrl + `thumbnails/?observation_id=${sessionId}&size=large`,
+    method: 'GET',
+    header: headers,
+    successCallback: (data) => {
+      if (data.results.length > 0) {
+        thumbnailsMap.value[sessionId] = data.results.map(result => result.url)
+      }
+      loading.value = false
+    },
+    failCallback: console.error
+  })
+}
+
+onMounted(() => {
+  filteredSessions.value.forEach(session => {
+    getThumbnails(session.id)
+  })
+})
+
+const sessionsWithThumbnails = computed(() => {
+  return filteredSessions.value.filter(session => thumbnailsMap.value[session.id] && thumbnailsMap.value[session.id].length > 0)
+})
 </script>
 
 <template>
-    <div class="container" v-for="obs in observations" :key="obs.id">
-        <h3>{{ formatDate(obs.start) }}</h3>
-        <div class="columns is-multiline">
-            <div class="column is-one-quarter-desktop is-half-tablet" v-for="id in obs" :key="id">
-            <figure class="image is-square">
-                <img :src="thumbnail" class="thumbnail" />
-            </figure>
-        </div>
+  <template v-if="loading">
+    <v-progress-circular indeterminate color="white" class="loading"/>
+  </template>
+  <div class="container" v-for="obs in sessionsWithThumbnails" :key="obs.id">
+    <h3>{{ formatDate(obs.start) }}</h3>
+    <div class="columns is-multiline">
+      <div
+        class="column is-one-quarter-desktop is-half-tablet"
+        v-for="(thumbnailUrl, i) in thumbnailsMap[obs.id]"
+        :key="obs.id + '-' + i">
+        <figure class="image is-square">
+          <img :src="thumbnailUrl" class="thumbnail" />
+        </figure>
+      </div>
     </div>
-    </div>
+  </div>
 </template>
+
+<style scoped>
+.loading {
+  position: relative;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+</style>

--- a/src/components/Images/MyGallery.vue
+++ b/src/components/Images/MyGallery.vue
@@ -47,6 +47,7 @@ const getThumbnails = async (sessionId) => {
 }
 
 onMounted(() => {
+  // Fetch thumbnails for all sessions in filteredSessions
   filteredSessions.value.forEach(session => {
     getThumbnails(session.id)
   })


### PR DESCRIPTION
## FEATURE: Display thumbnails from session on dashboard

**Background:**
The dashboard had hardcoded thumbnail placeholders. Now we get them from the thumbnail archive api and still applying the cut off time that was implemented before 

<img width="1728" alt="Screenshot 2024-08-15 at 3 39 24 PM" src="https://github.com/user-attachments/assets/eb697659-c680-4f18-be6e-b9e6811f797f">
