### PR TITLE
Feature/calendar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@fortawesome/pro-regular-svg-icons": "^6.6.0",
         "@fortawesome/vue-fontawesome": "^3.0.6",
+        "@popperjs/core": "^2.11.8",
         "@vuepic/vue-datepicker": "^9.0.3",
         "bulma": "^1.0.0",
         "core-js": "^3.8.3",
@@ -2645,7 +2646,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -14120,6 +14121,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/v-calendar/-/v-calendar-3.1.2.tgz",
       "integrity": "sha512-QDWrnp4PWCpzUblctgo4T558PrHgHzDtQnTeUNzKxfNf29FkCeFpwGd9bKjAqktaa2aJLcyRl45T5ln1ku34kg==",
+      "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.14.165",
         "@types/resize-observer-browser": "^0.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "pinia-plugin-persistedstate": "^3.2.1",
         "sass": "^1.75.0",
         "sass-loader": "^14.2.1",
-        "v-calendar": "^3.1.2",
+        "v-calendar": "^3.0.0",
         "vue": "^3.2.13",
         "vue-demi": "^0.14.10",
         "vue-router": "^4.3.2",
@@ -6206,6 +6206,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.8.tgz",
+      "integrity": "sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/debounce": {
@@ -14118,15 +14127,15 @@
       }
     },
     "node_modules/v-calendar": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/v-calendar/-/v-calendar-3.1.2.tgz",
-      "integrity": "sha512-QDWrnp4PWCpzUblctgo4T558PrHgHzDtQnTeUNzKxfNf29FkCeFpwGd9bKjAqktaa2aJLcyRl45T5ln1ku34kg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/v-calendar/-/v-calendar-3.0.0.tgz",
+      "integrity": "sha512-9r+swG8v2iUvaa2P1BGWEEeutZ+XCttHOzl0uXmzA7JND86GGZbM4QDPm8ZpBXav+NgheRm9MYs/Uz8mgKVZXg==",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.14.165",
         "@types/resize-observer-browser": "^0.1.7",
         "date-fns": "^2.16.1",
-        "date-fns-tz": "^2.0.0",
+        "date-fns-tz": "^1.0.12",
         "lodash": "^4.17.20",
         "vue-screen-utils": "^1.0.0-beta.13"
       },
@@ -14139,6 +14148,7 @@
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -14148,14 +14158,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
-      }
-    },
-    "node_modules/v-calendar/node_modules/date-fns-tz": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.1.tgz",
-      "integrity": "sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==",
-      "peerDependencies": {
-        "date-fns": "2.x"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@fortawesome/pro-regular-svg-icons": "^6.6.0",
     "@fortawesome/vue-fontawesome": "^3.0.6",
+    "@popperjs/core": "^2.11.8",
     "@vuepic/vue-datepicker": "^9.0.3",
     "bulma": "^1.0.0",
     "core-js": "^3.8.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "pinia-plugin-persistedstate": "^3.2.1",
     "sass": "^1.75.0",
     "sass-loader": "^14.2.1",
-    "v-calendar": "^3.1.2",
+    "v-calendar": "^3.0.0",
     "vue": "^3.2.13",
     "vue-demi": "^0.14.10",
     "vue-router": "^4.3.2",

--- a/src/components/RealTimeInterface/TimePicker.vue
+++ b/src/components/RealTimeInterface/TimePicker.vue
@@ -22,6 +22,9 @@ const localTimes = ref([])
 
 const timeInterval = 15
 
+const today = new Date()
+const oneWeekFromNow = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000)
+
 const emits = defineEmits(['timeSelected'])
 
 // Loads template only after the obs portal has returned available times
@@ -196,15 +199,6 @@ async function getAvailableTimes () {
   })
 }
 
-// Used to block out dates that are not in the availableTimes object from the date picker
-const isDateAllowed = (date) => {
-  // Gets the dates from availableTimes
-  const availableDates = Object.keys(availableTimes.value)
-  const firstDate = new Date(Math.min(...availableDates.map(date => new Date(date))))
-  const lastDate = new Date(Math.max(...availableDates.map(date => new Date(date))))
-  return date >= firstDate && date <= lastDate
-}
-
 // Handles both resetting the session and updating localTimes.value when the date changes
 watch(date, (newDate, oldDate) => {
   if (newDate !== oldDate) {
@@ -226,6 +220,7 @@ watch(startTime, (newTime, oldTime) => {
 onMounted(() => {
   getAvailableTimes()
 })
+
 </script>
 
 <template>
@@ -238,7 +233,15 @@ onMounted(() => {
       <div class="column is-one-third">
         <p>Select a date and time:</p>
         <div>
-          <v-date-picker v-model="date" class="blue-bg" :allowed-dates="isDateAllowed" @click="refreshTimes" />
+          <VDatePicker
+            v-model="date"
+            mode="date"
+            :min-date="today"
+            :max-date="oneWeekFromNow"
+            is-required
+            @update:model-value="refreshTimes"
+            expanded
+          />
         </div>
       </div>
       <div class="column">

--- a/src/components/Scheduling/AdvancedScheduling.vue
+++ b/src/components/Scheduling/AdvancedScheduling.vue
@@ -33,8 +33,8 @@ const handleExposuresUpdate = (exposures) => {
 }
 
 const handleDateRangeUpdate = (dateRange) => {
-  startDate.value = dateRange[0].toISOString().split('T')[0]
-  endDate.value = dateRange[1].toISOString().split('T')[0]
+  startDate.value = dateRange.start.toISOString().split('T')[0]
+  endDate.value = dateRange.end.toISOString().split('T')[0]
   emitSelections()
 }
 

--- a/src/components/Scheduling/BeginnerScheduling.vue
+++ b/src/components/Scheduling/BeginnerScheduling.vue
@@ -146,8 +146,8 @@ const fetchTargets = async (startDate, endDate) => {
 
 const handleDateRangeUpdate = (newDateRange) => {
   dateRange.value = newDateRange
-  startDate.value = newDateRange[0].toISOString().split('.')[0]
-  endDate.value = newDateRange[1].toISOString().split('.')[0]
+  startDate.value = newDateRange.start.toISOString().split('.')[0]
+  endDate.value = newDateRange.end.toISOString().split('.')[0]
   fetchTargets(startDate.value, endDate.value)
 }
 

--- a/src/components/Scheduling/Calendar.vue
+++ b/src/components/Scheduling/Calendar.vue
@@ -11,8 +11,8 @@ watch(dateRange, (newVal) => {
   emits('updateDateRange', newVal)
 })
 
-onMounted(() => {
-  fetchSemesterData()
+onMounted(async () => {
+  await fetchSemesterData()
 })
 
 </script>

--- a/src/components/Scheduling/Calendar.vue
+++ b/src/components/Scheduling/Calendar.vue
@@ -1,41 +1,27 @@
 <script setup>
 import { ref, watch, defineEmits } from 'vue'
-import VueDatePicker from '@vuepic/vue-datepicker'
-import '@vuepic/vue-datepicker/dist/main.css'
 
 const emits = defineEmits(['updateDateRange'])
 
-// here's the documentation for vuedatepicker:
-// https://vue3datepicker.com/props/general-configuration/
 const dateRange = ref()
+const today = new Date()
 
 watch(dateRange, (newVal) => {
   emits('updateDateRange', newVal)
 })
-
-const currentDate = new Date()
 
 </script>
 
 <template>
     <div class="container">
         <h3>Select a Date Range</h3>
-        <VueDatePicker
+        <VDatePicker
         v-model="dateRange"
-        range
-        :enable-time-picker="false"
-        :min-date="new Date()"
-        :max-date="new Date(currentDate.setDate(currentDate.getDate() + 15))"
+        mode="date"
+        is-range
+        :min-date="today"
         placeholder="Select Dates"
-        required
-        :date-range="dateRange"
-        class="custom-date-picker"
+        is-required
         />
     </div>
 </template>
-
-<style scoped>
-.custom-date-picker {
-    width: 20%;
-}
-</style>

--- a/src/components/Scheduling/Calendar.vue
+++ b/src/components/Scheduling/Calendar.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { ref, watch, defineEmits } from 'vue'
+import { ref, watch, defineEmits, onMounted } from 'vue'
+import { fetchSemesterData, currentSemesterEnd } from '../../utils/calendarUtils'
 
 const emits = defineEmits(['updateDateRange'])
 
@@ -8,6 +9,10 @@ const today = new Date()
 
 watch(dateRange, (newVal) => {
   emits('updateDateRange', newVal)
+})
+
+onMounted(() => {
+  fetchSemesterData()
 })
 
 </script>
@@ -20,6 +25,7 @@ watch(dateRange, (newVal) => {
         mode="date"
         is-range
         :min-date="today"
+        :max-date="new Date(currentSemesterEnd)"
         placeholder="Select Dates"
         is-required
         />

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,8 @@ import vuetify from './plugins/vuetify'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faBook, faStar, faChartLine, faCalendarDays, faGamepad, faChevronRight, faSquare, faThLarge, faGear, faSliders, faClock, faXmark, faPlusCircle, faDownload, faPenRuler, faListCheck } from '@fortawesome/free-solid-svg-icons'
 import { faTelescope, faLocationDot, faCameraRetro } from '@fortawesome/pro-regular-svg-icons'
+import VCalendar from 'v-calendar'
+import 'v-calendar/style.css'
 
 library.add(faBook, faStar, faChartLine, faCalendarDays, faGamepad, faChevronRight, faSquare, faThLarge, faGear, faSliders, faClock, faXmark, faPlusCircle, faDownload, faPenRuler, faTelescope, faLocationDot, faCameraRetro, faListCheck)
 
@@ -19,4 +21,5 @@ createApp(App)
   .use(router)
   .use(vuetify)
   .use(pinia)
+  .use(VCalendar, {})
   .mount('#app')

--- a/src/tests/integration/components/beginnerScheduling.test.js
+++ b/src/tests/integration/components/beginnerScheduling.test.js
@@ -13,7 +13,6 @@ describe('BeginnerScheduling.vue', () => {
   let wrapper
 
   beforeEach(() => {
-    console.log('clearing')
     fetchApiCall.mockClear()
     const { pinia } = createTestStores()
 

--- a/src/tests/integration/components/beginnerScheduling.test.js
+++ b/src/tests/integration/components/beginnerScheduling.test.js
@@ -13,6 +13,7 @@ describe('BeginnerScheduling.vue', () => {
   let wrapper
 
   beforeEach(() => {
+    console.log('clearing')
     fetchApiCall.mockClear()
     const { pinia } = createTestStores()
 
@@ -46,14 +47,16 @@ describe('BeginnerScheduling.vue', () => {
     const endDate = new Date()
     // Adds 15 days to the start date
     endDate.setDate(startDate.getDate() + 15)
-
-    const newDateRange = [startDate, endDate]
-
+    const newDateRange = {
+      start: startDate,
+      end: endDate
+    }
     await wrapper.vm.handleDateRangeUpdate(newDateRange)
 
-    expect(fetchApiCall).toHaveBeenCalledTimes(1)
+    // Because the Calendar component is a child of BeginnerScheduling, this test also makes the api call to fetch semester data (which is not tested here)
+    expect(fetchApiCall).toHaveBeenCalledTimes(2)
     expect(fetchApiCall).toHaveBeenCalledWith({
-      url: `https://whatsup.lco.global/range/?start=${startDate.toISOString().split('.')[0]}&end=${endDate.toISOString().split('.')[0]}&aperture=0m4&mode=full`,
+      url: `https://whatsup.lco.global/range/?start=${newDateRange.start.toISOString().split('.')[0]}&end=${newDateRange.end.toISOString().split('.')[0]}&aperture=0m4&mode=full`,
       method: 'GET',
       successCallback: expect.any(Function),
       failCallback: expect.any(Function)

--- a/src/tests/integration/components/calendar.test.js
+++ b/src/tests/integration/components/calendar.test.js
@@ -1,0 +1,47 @@
+import { shallowMount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Calendar from '../../../components/Scheduling/Calendar.vue'
+import { fetchSemesterData, currentSemesterEnd } from '../../../utils/calendarUtils'
+import flushPromises from 'flush-promises'
+
+vi.mock('../../../utils/calendarUtils', () => ({
+  fetchSemesterData: vi.fn(),
+  currentSemesterEnd: '2024-08-01T12:00:00Z'
+}))
+
+describe('Calendar.vue', () => {
+  let wrapper
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    const VDatePickerStub = {
+      name: 'VDatePicker',
+      template: '<div></div>',
+      props: ['max-date']
+    }
+
+    wrapper = shallowMount(Calendar, {
+      global: {
+        stubs: {
+          VDatePicker: VDatePickerStub
+        }
+      }
+    })
+  })
+
+  it('calls fetchSemesterData on mount', () => {
+    expect(fetchSemesterData).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes the correct max-date to VDatePicker', async () => {
+    await flushPromises()
+    const datePicker = wrapper.findComponent({ name: 'VDatePicker' })
+    expect(datePicker.exists()).toBe(true)
+    // Note: The prop name 'maxDate' is camel-cased instead of using 'max-date' because Vue automatically converts kebab-case prop names to camelCase
+    // when passing them in js. In templates, we use 'max-date', but when accessing props programmatically, we use 'maxDate'
+    const maxDateProp = datePicker.props('maxDate')
+    const maxDateIsoString = new Date(maxDateProp).toISOString().split('.')[0] + 'Z'
+    expect(maxDateIsoString).toBe(currentSemesterEnd)
+  })
+})

--- a/src/tests/unit/utils/calendarUtils.test.js
+++ b/src/tests/unit/utils/calendarUtils.test.js
@@ -1,0 +1,50 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { fetchApiCall } from '../../../utils/api.js'
+import { fetchSemesterData, currentSemesterEnd, currentSemesterStart } from '../../../utils/calendarUtils.js'
+import { createTestStores } from '../../../utils/testUtils'
+
+vi.mock('@/utils/api.js', () => ({
+  fetchApiCall: vi.fn()
+}))
+
+describe('calendarUtils.js', () => {
+  let configurationStore
+
+  beforeEach(() => {
+    const { configurationStore: store } = createTestStores()
+    configurationStore = store
+    fetchApiCall.mockClear()
+  })
+
+  describe('fetchSemesterData', () => {
+    it('sets currentSemesterStart and currentSemesterEnd after making the fetchApiCall', async () => {
+      const mockResponse = {
+        results: [
+          { start: '2024-01-01', end: '2024-06-30' },
+          { start: '2024-07-01', end: '2024-12-31' }
+        ]
+      }
+
+      // Mocking today's date to ensure the correct semester is selected
+      const today = new Date('2024-08-15')
+      // This sets the system time to the provided date
+      vi.setSystemTime(today)
+
+      fetchApiCall.mockImplementationOnce(({ successCallback }) => {
+        successCallback(mockResponse)
+      })
+
+      await fetchSemesterData()
+
+      expect(fetchApiCall).toHaveBeenCalledTimes(1)
+      expect(fetchApiCall).toHaveBeenCalledWith({
+        url: 'http://mock-api.com/semesters/',
+        method: 'GET',
+        successCallback: expect.any(Function)
+      })
+
+      expect(currentSemesterStart).toBe('2024-07-01')
+      expect(currentSemesterEnd).toBe('2024-12-31')
+    })
+  })
+})

--- a/src/utils/calendarUtils.js
+++ b/src/utils/calendarUtils.js
@@ -1,0 +1,33 @@
+import { fetchApiCall } from './api.js'
+import { useConfigurationStore } from '../stores/configuration.js'
+
+let currentSemesterStart = null
+let currentSemesterEnd = null
+
+const getStartAndEndDatesOfCurrentSemester = (semesters) => {
+  const today = new Date()
+  const currentSemester = semesters.find(semester => {
+    const startDate = new Date(semester.start)
+    const endDate = new Date(semester.end)
+    return today >= startDate && today <= endDate
+  })
+  if (currentSemester) {
+    currentSemesterStart = currentSemester.start
+    currentSemesterEnd = currentSemester.end
+  }
+}
+
+const fetchSemesterData = async () => {
+  const configurationStore = useConfigurationStore()
+  const observationPortalUrl = configurationStore.observationPortalUrl
+  await fetchApiCall({
+    url: `${observationPortalUrl}semesters/`,
+    method: 'GET',
+    successCallback: (response) => {
+      const semesters = response.results
+      getStartAndEndDatesOfCurrentSemester(semesters)
+    }
+  })
+}
+
+export { currentSemesterStart, currentSemesterEnd, fetchSemesterData }


### PR DESCRIPTION
## FEATURE/FIX: Using same calendar when booking RTI and requesting observations

**Background:**
More than one style of calendar was being used and that was because I couldn't find a date picker and a date range picker but now I've found an older version of a package and it works well. 

**Implementation:**
- Initialized the component on `main.js`
- Changed the component in `TimePicker` (that one was pretty simple, not much changed)
- Tweaked a little bit of logic in `BeginnerScheduling` and `AdvancedScheduling` because the component `VDatePicker` contains the object keys of `start` and `end` from the package.
- Added `calendarUtils` but have to discuss with Edward how these should be used. Basically, this gets the start and end dates of the current semester and its purpose is meant to set limits
- And added and updated tests


### VISUALS
**Calendar when booking for RTI**
<img width="628" alt="Screenshot 2024-11-12 at 1 40 22 PM" src="https://github.com/user-attachments/assets/83516971-80bb-4339-a24e-db75e164a48e">

**Calendar when requesting a scheduled observation (end of current semester is Jan 31)**

https://github.com/user-attachments/assets/35808fa6-d1a6-4ad9-ac6b-ff38e9079c92

