### PR TITLE
fixes calendar bug

### DIFF
--- a/src/components/Scheduling/AdvancedScheduling.vue
+++ b/src/components/Scheduling/AdvancedScheduling.vue
@@ -51,8 +51,7 @@ const emitSelections = () => {
 </script>
 
 <template>
-  <h2>Photon Ranch</h2>
-  <h4>Requesting an Observation</h4>
+  <h2>Request an Observation</h2>
 
   <SchedulingSettings
     :show-project-field="true"
@@ -65,16 +64,7 @@ const emitSelections = () => {
 </template>
 
 <style scoped>
-h2 {
-  margin-top: 1em;
-}
-.input-wrapper {
-  margin: 1em;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-}
+
 .p-text {
   margin-right: 1em;
   font-size: 1.2em;

--- a/src/components/Scheduling/Calendar.vue
+++ b/src/components/Scheduling/Calendar.vue
@@ -25,7 +25,7 @@ onMounted(async () => {
         mode="date"
         is-range
         :min-date="today"
-        :max-date="new Date(currentSemesterEnd)"
+        :max-date="currentSemesterEnd"
         placeholder="Select Dates"
         is-required
         />

--- a/src/components/Scheduling/Calendar.vue
+++ b/src/components/Scheduling/Calendar.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, watch, defineEmits, onMounted } from 'vue'
-import { fetchSemesterData, currentSemesterEnd } from '../../utils/calendarUtils'
+import { fetchSemesterData, currentSemesterEnd, parseISOString } from '../../utils/calendarUtils'
 
 const emits = defineEmits(['updateDateRange'])
 
@@ -25,9 +25,13 @@ onMounted(async () => {
         mode="date"
         is-range
         :min-date="today"
-        :max-date="currentSemesterEnd"
+        :max-date="parseISOString(currentSemesterEnd)"
         placeholder="Select Dates"
         is-required
-        />
+        @dayclick="
+        (_, event) => {
+          event.target.blur();
+        }
+      " />
     </div>
 </template>

--- a/src/components/Views/SchedulingView.vue
+++ b/src/components/Views/SchedulingView.vue
@@ -135,6 +135,7 @@ const enableButton = computed(() => {
 </script>
 
 <template>
+  <section class="section  highlight">
   <div class="container">
     <div v-if="!level && !showScheduled" class="level-buttons-wrapper">
       <h2>Submit a Request</h2>
@@ -155,7 +156,8 @@ const enableButton = computed(() => {
     <div v-if="showScheduled">
       <ScheduledObservations />
     </div>
-  </div>
+    </div>
+  </section>
 </template>
 
 <style scoped>

--- a/src/tests/integration/components/calendar.test.js
+++ b/src/tests/integration/components/calendar.test.js
@@ -4,10 +4,21 @@ import Calendar from '../../../components/Scheduling/Calendar.vue'
 import { fetchSemesterData, currentSemesterEnd } from '../../../utils/calendarUtils'
 import flushPromises from 'flush-promises'
 
-vi.mock('../../../utils/calendarUtils', () => ({
-  fetchSemesterData: vi.fn(),
-  currentSemesterEnd: '2024-08-01T12:00:00Z'
-}))
+// Partially mock the calendarUtils module
+// The terminal suggested using 'importOriginal' to do a partial mock.
+// This is necessary because we want to mock some exports (like 'fetchSemesterData' and 'currentSemesterEnd')
+// while keeping other exports (like 'parseISOString') unchanged and available.
+// 'importOriginal' represents the original module with all its exports.
+// Using 'actual' will hold all original exports, then spread them to preserve the original functionality.
+vi.mock('../../../utils/calendarUtils', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    // Include all original exports
+    ...actual,
+    fetchSemesterData: vi.fn(),
+    currentSemesterEnd: '2024-08-01T12:00:00Z'
+  }
+})
 
 describe('Calendar.vue', () => {
   let wrapper

--- a/src/utils/calendarUtils.js
+++ b/src/utils/calendarUtils.js
@@ -4,6 +4,12 @@ import { useConfigurationStore } from '../stores/configuration.js'
 let currentSemesterStart = null
 let currentSemesterEnd = null
 
+function parseISOString (s) {
+  if (s === null) return null
+  const b = s.split(/\D+/)
+  return new Date(Date.UTC(b[0], --b[1], b[2], b[3], b[4], b[5], b[6]))
+}
+
 const getStartAndEndDatesOfCurrentSemester = (semesters) => {
   const today = new Date()
   const currentSemester = semesters.find(semester => {
@@ -30,4 +36,4 @@ const fetchSemesterData = async () => {
   })
 }
 
-export { currentSemesterStart, currentSemesterEnd, fetchSemesterData }
+export { currentSemesterStart, currentSemesterEnd, fetchSemesterData, parseISOString }


### PR DESCRIPTION
## QUICK FIX: Calendar bug

**Background:**
Edward pointed out that the calendar rendered January 1970 on his end as the initial page. This was probably due to setting the `max-date` as `new Date(currentSemesterEnd)` rather than just having `currentSemesterEnd` which already is a date

On my end, after further inspection, I noticed that it would sometimes block out the initial page (November 2024)
<img width="303" alt="Screenshot 2024-11-18 at 1 26 01 PM" src="https://github.com/user-attachments/assets/39071c00-ada6-4160-9dbd-e19dcd6c0b5d">
