### PR TITLE
Fix/proposal

### DIFF
--- a/src/components/Global/ProposalDropdown.vue
+++ b/src/components/Global/ProposalDropdown.vue
@@ -1,20 +1,34 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, watch, defineEmits } from 'vue'
 import { useUserDataStore } from '../../stores/userData'
+
+const emit = defineEmits(['selectionsComplete'])
 
 const userDataStore = useUserDataStore()
 const proposals = userDataStore.profile.proposals
 
 const selectedProposal = ref()
 
+watch(selectedProposal, (newValue) => {
+  emit('selectionsComplete', newValue)
+})
+
 </script>
+
 <template>
+  <template v-if="proposals.length">
     <div>
-    <label for="proposalSelect">Select a prosposal:</label>
-    <select id="proposalSelect" v-model="selectedProposal">
-      <option v-for="proposal in proposals" :key="proposal.id" :value="proposal.id">
-        {{ proposal.id }}
-      </option>
-    </select>
-  </div>
+      <label for="proposalSelect">Select a proposal:</label>
+      <select id="proposalSelect" v-model="selectedProposal">
+        <option v-for="proposal in proposals" :key="proposal.id" :value="proposal.id">
+          {{ proposal.id }}
+        </option>
+      </select>
+    </div>
+  </template>
+  <template v-else>
+    <div>
+      <p>No proposals found. Please create a proposal <a href="https://observe.lco.global/apply">here</a></p>
+    </div>
+  </template>
 </template>

--- a/src/components/Global/ProposalDropdown.vue
+++ b/src/components/Global/ProposalDropdown.vue
@@ -6,6 +6,7 @@ const emit = defineEmits(['selectionsComplete'])
 
 const userDataStore = useUserDataStore()
 const proposals = userDataStore.profile.proposals
+const activeProposals = proposals.filter(proposal => proposal.current === true)
 
 const selectedProposal = ref()
 
@@ -20,7 +21,7 @@ watch(selectedProposal, (newValue) => {
     <div>
       <label for="proposalSelect">Select a proposal:</label>
       <select id="proposalSelect" v-model="selectedProposal">
-        <option v-for="proposal in proposals" :key="proposal.id" :value="proposal.id">
+        <option v-for="proposal in activeProposals" :key="proposal.id" :value="proposal.id">
           {{ proposal.id }}
         </option>
       </select>

--- a/src/components/Global/ProposalDropdown.vue
+++ b/src/components/Global/ProposalDropdown.vue
@@ -22,7 +22,7 @@ const selectedProposal = ref()
       @change="emit('selectionsComplete', selectedProposal)"
       >
         <option v-for="proposal in activeProposals" :key="proposal.id" :value="proposal.id">
-          {{ proposal.id }}
+          {{ proposal.title }}
         </option>
       </select>
     </div>

--- a/src/components/Global/ProposalDropdown.vue
+++ b/src/components/Global/ProposalDropdown.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { ref } from 'vue'
+import { useUserDataStore } from '../../stores/userData'
+
+const userDataStore = useUserDataStore()
+const proposals = userDataStore.profile.proposals
+
+const selectedProposal = ref()
+
+</script>
+<template>
+    <div>
+    <label for="proposalSelect">Select a prosposal:</label>
+    <select id="proposalSelect" v-model="selectedProposal">
+      <option v-for="proposal in proposals" :key="proposal.id" :value="proposal.id">
+        {{ proposal.id }}
+      </option>
+    </select>
+  </div>
+</template>

--- a/src/components/Global/ProposalDropdown.vue
+++ b/src/components/Global/ProposalDropdown.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch, defineEmits } from 'vue'
+import { ref, defineEmits } from 'vue'
 import { useUserDataStore } from '../../stores/userData'
 
 const emit = defineEmits(['selectionsComplete'])
@@ -10,17 +10,17 @@ const activeProposals = proposals.filter(proposal => proposal.current === true)
 
 const selectedProposal = ref()
 
-watch(selectedProposal, (newValue) => {
-  emit('selectionsComplete', newValue)
-})
-
 </script>
 
 <template>
   <template v-if="proposals.length">
     <div>
       <label for="proposalSelect">Select a proposal:</label>
-      <select id="proposalSelect" v-model="selectedProposal">
+      <select
+      id="proposalSelect"
+      v-model="selectedProposal"
+      @change="emit('selectionsComplete', selectedProposal)"
+      >
         <option v-for="proposal in activeProposals" :key="proposal.id" :value="proposal.id">
           {{ proposal.id }}
         </option>

--- a/src/components/RealTimeInterface/TimePicker.vue
+++ b/src/components/RealTimeInterface/TimePicker.vue
@@ -7,6 +7,7 @@ import { fetchApiCall } from '../../utils/api'
 import { formatToUTC, formatDate } from '../../utils/formatTime.js'
 import { useConfigurationStore } from '../../stores/configuration'
 import LeafletMap from './GlobeMap/LeafletMap.vue'
+import ProposalDropdown from '../Global/ProposalDropdown.vue'
 
 const router = useRouter()
 const realTimeSessionsStore = useRealTimeSessionsStore()
@@ -19,6 +20,7 @@ const errorMessage = ref(null)
 const selectedSite = ref(null)
 const availableTimes = ref({})
 const localTimes = ref([])
+const selectedProposal = ref()
 
 const timeInterval = 15
 const today = ref(new Date())
@@ -171,7 +173,7 @@ const blockRti = async () => {
   }
 
   const requestBody = {
-    proposal: 'LCORealtimeTest',
+    proposal: selectedProposal.value,
     name: 'Test Real Time',
     site: selectedSite.value.site,
     enclosure,
@@ -254,8 +256,9 @@ onMounted(() => {
   </template>
   <template v-if="hasAvailableTimes">
     <h2>Book your live observing session</h2>
+    <ProposalDropdown @selectionsComplete="(proposal) => { selectedProposal = proposal }" />
     <div class="columns">
-      <div class="column is-one-third">
+      <div v-if="selectedProposal" class="column is-one-third">
         <p>Select a date and time:</p>
         <div>
           <VDatePicker

--- a/src/components/Scheduling/AdvancedScheduling.vue
+++ b/src/components/Scheduling/AdvancedScheduling.vue
@@ -1,11 +1,13 @@
 <script setup>
 import { ref } from 'vue'
 import SchedulingSettings from './SchedulingSettings.vue'
+import ProposalDropdown from '../Global/ProposalDropdown.vue'
 import Calendar from './Calendar.vue'
 
 const targetsData = ref([])
 const startDate = ref('')
 const endDate = ref('')
+const selectedProposal = ref()
 
 // Handle each target update and store it in the array
 const handleTargetUpdate = (target) => {
@@ -40,11 +42,12 @@ const handleDateRangeUpdate = (dateRange) => {
 
 const emits = defineEmits(['selectionsComplete'])
 const emitSelections = () => {
-  if (targetsData.value.length > 0 && startDate.value && endDate.value) {
+  if (targetsData.value.length > 0 && startDate.value && endDate.value && selectedProposal.value) {
     emits('selectionsComplete', {
       targets: targetsData.value,
       startDate: startDate.value,
-      endDate: endDate.value
+      endDate: endDate.value,
+      proposal: selectedProposal.value
     })
   }
 }
@@ -60,7 +63,7 @@ const emitSelections = () => {
     @targetUpdated="handleTargetUpdate"
     @exposuresUpdated="handleExposuresUpdate"
   />
-
+  <ProposalDropdown @selectionsComplete="(proposal) => { selectedProposal = proposal }"/>
   <Calendar @updateDateRange="handleDateRangeUpdate" />
 </template>
 

--- a/src/components/Scheduling/BeginnerScheduling.vue
+++ b/src/components/Scheduling/BeginnerScheduling.vue
@@ -3,6 +3,7 @@ import { ref, defineEmits } from 'vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import Calendar from './Calendar.vue'
 import SchedulingSettings from './SchedulingSettings.vue'
+import ProposalDropdown from '../Global/ProposalDropdown.vue'
 import { fetchApiCall } from '../../utils/api.js'
 
 const emits = defineEmits(['selectionsComplete', 'showButton'])
@@ -19,6 +20,7 @@ const loading = ref(false)
 const selectedTargets = ref([])
 const startDate = ref('')
 const endDate = ref('')
+const selectedProposal = ref()
 
 const categories = ref([
   {
@@ -81,7 +83,8 @@ const emitSelections = () => {
     target: targetSelection.value,
     settings: exposureSettings.value,
     startDate: startDate.value,
-    endDate: endDate.value
+    endDate: endDate.value,
+    proposal: selectedProposal.value
   })
   // }
 }
@@ -187,9 +190,10 @@ const handleExposuresUpdate = (exposures) => {
   </template>
   <div class="container">
     <div v-if="!dateRange">
-    <Calendar @updateDateRange="handleDateRangeUpdate"/>
+    <ProposalDropdown @selectionsComplete="(proposal) => { selectedProposal = proposal }"/>
+    <Calendar v-if="selectedProposal" @updateDateRange="handleDateRangeUpdate"/>
   </div>
-    <div v-if="!objectSelected && dateRange && !loading" class="content">
+    <div v-if="!objectSelected && dateRange && !loading && selectedProposal" class="content">
       <h2>Schedule an Observation</h2>
       <p>What do you want to take pictures of?</p>
       <div v-for="category in categories" :key="category.location" class="content">

--- a/src/components/Views/SchedulingView.vue
+++ b/src/components/Views/SchedulingView.vue
@@ -107,7 +107,6 @@ const sendObservationRequest = async () => {
       method: 'POST',
       body: {
         'name': 'UserObservation',
-        // TO DO: get proposals from user and use the proposal ID here
         'proposal': observationData.value.proposal,
         'ipp_value': 1.05,
         'operator': operatorValue.value,

--- a/src/components/Views/SchedulingView.vue
+++ b/src/components/Views/SchedulingView.vue
@@ -108,7 +108,7 @@ const sendObservationRequest = async () => {
       body: {
         'name': 'UserObservation',
         // TO DO: get proposals from user and use the proposal ID here
-        'proposal': 'LCOSchedulerTest',
+        'proposal': observationData.value.proposal,
         'ipp_value': 1.05,
         'operator': operatorValue.value,
         'observation_type': 'NORMAL',

--- a/src/tests/integration/components/schedulingView.test.js
+++ b/src/tests/integration/components/schedulingView.test.js
@@ -31,7 +31,8 @@ describe('SchedulingView.vue', () => {
       ],
       startDate: new Date(),
       // 1 hour later
-      endDate: new Date(new Date().getTime() + 3600 * 1000)
+      endDate: new Date(new Date().getTime() + 3600 * 1000),
+      proposal: 'Test Proposal'
     }
 
     const mockRequestList = [
@@ -114,7 +115,7 @@ describe('SchedulingView.vue', () => {
       method: 'POST',
       body: {
         name: 'UserObservation',
-        proposal: 'LCOSchedulerTest',
+        proposal: 'Test Proposal',
         ipp_value: 1.05,
         operator: 'SINGLE',
         observation_type: 'NORMAL',


### PR DESCRIPTION
## FIX/FEATURE: Proposal id selection
**Background:**
The proposal id was hardcoded when users requested a scheduled observation and an rti. Now, the user's proposals are presented as a drop down and they get to select it. If there are no proposals associated with the user, then they are presented with a link to submit a proposal at LCO. The last part may be temporary.


### VISUALS
**This is what it looks like on every component**
<img width="573" alt="Screenshot 2024-11-18 at 5 09 52 PM" src="https://github.com/user-attachments/assets/ba38348a-0433-4a82-9a41-ff06e2a132ec">
