### PR TITLE
Feature/shuffle targets

### DIFF
--- a/src/components/Scheduling/BeginnerScheduling.vue
+++ b/src/components/Scheduling/BeginnerScheduling.vue
@@ -97,7 +97,6 @@ const loadMoreTargets = () => {
 }
 
 const emitSelections = () => {
-  // if (targetSelection.value && exposureSettings.value.length > 0) {
   emits('selectionsComplete', {
     target: targetSelection.value,
     settings: exposureSettings.value,
@@ -105,7 +104,6 @@ const emitSelections = () => {
     endDate: endDate.value,
     proposal: selectedProposal.value
   })
-  // }
 }
 
 const handleTargetSelection = (target) => {

--- a/src/components/Scheduling/BeginnerScheduling.vue
+++ b/src/components/Scheduling/BeginnerScheduling.vue
@@ -105,7 +105,8 @@ const loadMoreTargets = () => {
   if (currentCategoryTargets.length === 0) return
 
   // Calculate the new total to load, up to a maximum of 15 or the total number of targets
-  const newTotalLoaded = Math.min(totalLoaded.value + 3, currentCategoryTargets.length, 15)
+  const maxNumberOfTargets = 15
+  const newTotalLoaded = Math.min(totalLoaded.value + 3, currentCategoryTargets.length, maxNumberOfTargets)
   displayedTargets.value = currentCategoryTargets.slice(0, newTotalLoaded).map(target => ({
     name: target.name,
     desc: target.desc,

--- a/src/components/Scheduling/BeginnerScheduling.vue
+++ b/src/components/Scheduling/BeginnerScheduling.vue
@@ -23,6 +23,7 @@ const endDate = ref('')
 const selectedProposal = ref()
 const displayedTargets = ref([])
 const totalLoaded = ref(3)
+const allCategoryTargets = ref({})
 
 const categories = ref([
   {
@@ -67,7 +68,10 @@ const handleObjectSelection = (option) => {
 
   const filteredTargets = selectedTargets.value.filter(
     target => target.avmdesc.match(categoryRegex)
-  ).slice(0, 3)
+  )
+
+  // Store all targets for this category in allCategoryTargets
+  allCategoryTargets.value[option.object] = filteredTargets
 
   // Populate the targets for the selected object
   objectSelection.value.targets = filteredTargets.map(target => ({
@@ -82,17 +86,33 @@ const handleObjectSelection = (option) => {
 }
 
 const shuffleTargets = () => {
-  const allTargets = selectedTargets.value
-  // Shuffles the full list of targets and take the first 3
-  const shuffled = allTargets.sort(() => Math.random() - 0.5).slice(0, 3)
-  displayedTargets.value = shuffled
+  const currentCategoryTargets = allCategoryTargets.value[objectSelection.value.object] || []
+  if (currentCategoryTargets.length === 0) return
+
+  // Shuffle the full list of targets for this category and take the first 3
+  const shuffled = [...currentCategoryTargets].sort(() => Math.random() - 0.5).slice(0, 3)
+  displayedTargets.value = shuffled.map(target => ({
+    name: target.name,
+    desc: target.desc,
+    filters: target.filters,
+    ra: target.ra,
+    dec: target.dec
+  }))
 }
 
 const loadMoreTargets = () => {
-  const allTargets = selectedTargets.value
-  // Calculates the new total of targets to load and stops at 15 or the total number of targets, whichever is smaller
-  const newTotalLoaded = Math.min(totalLoaded.value + 3, allTargets.length, 15)
-  displayedTargets.value = allTargets.slice(0, newTotalLoaded)
+  const currentCategoryTargets = allCategoryTargets.value[objectSelection.value.object] || []
+  if (currentCategoryTargets.length === 0) return
+
+  // Calculate the new total to load, up to a maximum of 15 or the total number of targets
+  const newTotalLoaded = Math.min(totalLoaded.value + 3, currentCategoryTargets.length, 15)
+  displayedTargets.value = currentCategoryTargets.slice(0, newTotalLoaded).map(target => ({
+    name: target.name,
+    desc: target.desc,
+    filters: target.filters,
+    ra: target.ra,
+    dec: target.dec
+  }))
   totalLoaded.value = newTotalLoaded
 }
 

--- a/src/components/Scheduling/BeginnerScheduling.vue
+++ b/src/components/Scheduling/BeginnerScheduling.vue
@@ -21,6 +21,8 @@ const selectedTargets = ref([])
 const startDate = ref('')
 const endDate = ref('')
 const selectedProposal = ref()
+const displayedTargets = ref([])
+const totalLoaded = ref(3)
 
 const categories = ref([
   {
@@ -75,6 +77,23 @@ const handleObjectSelection = (option) => {
     ra: target.ra,
     dec: target.dec
   }))
+  displayedTargets.value = objectSelection.value.targets.slice(0, 3)
+  totalLoaded.value = 3
+}
+
+const shuffleTargets = () => {
+  const allTargets = selectedTargets.value
+  // Shuffles the full list of targets and take the first 3
+  const shuffled = allTargets.sort(() => Math.random() - 0.5).slice(0, 3)
+  displayedTargets.value = shuffled
+}
+
+const loadMoreTargets = () => {
+  const allTargets = selectedTargets.value
+  // Calculates the new total of targets to load and stops at 15 or the total number of targets, whichever is smaller
+  const newTotalLoaded = Math.min(totalLoaded.value + 3, allTargets.length, 15)
+  displayedTargets.value = allTargets.slice(0, newTotalLoaded)
+  totalLoaded.value = newTotalLoaded
 }
 
 const emitSelections = () => {
@@ -213,7 +232,7 @@ const handleExposuresUpdate = (exposures) => {
     <div v-if="objectSelected && !targetSelected && objectSelection.targets">
   <h3>Requesting an Observation of a <span class="blue">{{ objectSelection.object }}</span></h3>
   <div class="columns is-column-gap-3">
-    <div v-for="target in objectSelection.targets" :key="target.name" @click="handleTargetSelection(target)" class="column">
+    <div v-for="target in displayedTargets" :key="target.name" @click="handleTargetSelection(target)" class="column">
       <div class="card target-highlight is-clickable">
         <header class="card-header">
           <p class="card-header-title">{{ target.name }}</p>
@@ -227,6 +246,8 @@ const handleExposuresUpdate = (exposures) => {
     </div>
   </div>
   <button class="button" @click="resetSelections">Different targets</button>
+  <button class="button" @click="shuffleTargets">Shuffle Targets</button>
+  <button class="button" v-if="totalLoaded < selectedTargets.length && totalLoaded < 15" @click="loadMoreTargets">Load More Targets</button>
 </div>
 <div v-if="targetSelected || (objectSelected && !objectSelection.targets)" class="content">
   <h2>


### PR DESCRIPTION
## FEATURE: Shuffle and load more targets
**Background:**
When users would request a scheduled observation, selected beginner mode, and then selected an object category (e.g. supernova), only 3 targets would load and they could only select from those 3. Now, there is the option to shuffle targets and to load more targets (within the same object category).

The next task is to add a `Go Back` and `Start Over` buttons.

**Implementation:**
- `handleObjectSelection`: now populates `allCategoryTargets` and initializes `displayedTargets` with the first 3 targets
- `shuffleTargets`: randomly selects 3 targets from the full list of targets in the current category. The new targets have the key:value pairs as the first 3 targets that load so that the `filters`, `ra`, and `dec` are saved.
`loadMoreTargets`: adds up to 3 more targets to `displayedTargets` and does not exceed 15 targets (arbitrary number, can get rid of this) or the number of available targets.

### VISUALS
**Screen recording of shuffling targets and loading more targets**

https://github.com/user-attachments/assets/0a17393c-5641-410c-a803-17e9d4230b75

