### PR TITLE
filters thumbnails to only get reduced thumbnails

### DIFF
--- a/src/tests/unit/utils/thumbnailsUtils.test.js
+++ b/src/tests/unit/utils/thumbnailsUtils.test.js
@@ -17,14 +17,14 @@ describe('thumbnailsUtils.js', () => {
   })
 
   describe('getThumbnails', () => {
-    it('fetches thumbnails for a given queryValue', async () => {
+    it('fetches thumbnails for a given queryValue and returns only reduced thumbnails', async () => {
       const mockResponse = {
         results: [
           {
             'id': 123,
             'frame': 789,
             'size': 'small',
-            'basename': 'mockbasename-1-small_thumbnail',
+            'basename': 'mockbasename-e91-1-small_thumbnail',
             'extension': '.jpg',
             'key': 'secret1',
             'url': 'http://mock-api.com/thumbnails/1'
@@ -33,7 +33,7 @@ describe('thumbnailsUtils.js', () => {
             'id': 456,
             'frame': 321,
             'size': 'small',
-            'basename': 'mockbasename-2-small_thumbnail',
+            'basename': 'mockbasename-notreduced-2-small_thumbnail',
             'extension': '.jpg',
             'key': 'secret2',
             'url': 'http://mock-api.com/thumbnails/2'
@@ -60,19 +60,10 @@ describe('thumbnailsUtils.js', () => {
           'id': 123,
           'frame': 789,
           'size': 'small',
-          'basename': 'mockbasename-1-small_thumbnail',
+          'basename': 'mockbasename-e91-1-small_thumbnail',
           'extension': '.jpg',
           'key': 'secret1',
           'url': 'http://mock-api.com/thumbnails/1'
-        },
-        {
-          'id': 456,
-          'frame': 321,
-          'size': 'small',
-          'basename': 'mockbasename-2-small_thumbnail',
-          'extension': '.jpg',
-          'key': 'secret2',
-          'url': 'http://mock-api.com/thumbnails/2'
         }
       ])
     })

--- a/src/utils/thumbnailsUtils.js
+++ b/src/utils/thumbnailsUtils.js
@@ -9,7 +9,12 @@ const getThumbnails = async (param, queryValue) => {
     method: 'GET',
     successCallback: (data) => {
       if (data.results.length > 0) {
-        data.results.forEach(result => thumbnails.push(result))
+        data.results.forEach(result => {
+          // There is no filter for reduction_level in the thumbnails endpoint
+          if (result.basename.includes('e91')) {
+            thumbnails.push(result)
+          }
+        })
       }
     },
     failCallback: (error) => {


### PR DESCRIPTION
## QUICK FIX - Filtering thumbnails to only render reduced ones

**IMPLEMENTATION:**
 There is no filter for `reduction_level` in the thumbnails endpoint so I added a simple step to check if the basename includes `e91` then include it in the thumbnails

### VISUALS
**Before**
<img width="901" alt="Screenshot 2025-02-06 at 11 35 19 AM" src="https://github.com/user-attachments/assets/97b0cd65-e894-4288-8c85-57470400e4c1" />
**After**
<img width="873" alt="Screenshot 2025-02-06 at 11 34 53 AM" src="https://github.com/user-attachments/assets/5dc2d7d8-af99-47d9-bbc6-915844f3d178" />

