### PR TITLE
Feature/paginate rtis

### DIFF
--- a/src/components/Dashboard/UpcomingBookings.vue
+++ b/src/components/Dashboard/UpcomingBookings.vue
@@ -12,17 +12,32 @@ const realTimeSessionsStore = useRealTimeSessionsStore()
 const configurationStore = useConfigurationStore()
 const obsPortalDataStore = useObsPortalDataStore()
 
+const currentPage = ref(1)
+const sessionsPerPage = 5
 const requestGroups = ref([])
 // change to bookings and add an icon to show completion
 const sortedSessions = computed(() => {
   const now = new Date().getTime()
-  // TODO: Show past sessions for a certain amount of time in a separate section
   const twoHoursAgo = now - 120 * 60 * 1000
   const sessions = Object.values(obsPortalDataStore.upcomingRealTimeSessions)
   return sessions.filter(session => new Date(session.start).getTime() >= twoHoursAgo)
     .slice()
     .sort((a, b) => new Date(a.start) - new Date(b.start))
 })
+
+const paginatedSessions = computed(() => {
+  const start = (currentPage.value - 1) * sessionsPerPage
+  const end = start + sessionsPerPage
+  return sortedSessions.value.slice(start, end)
+})
+
+const totalPages = computed(() => {
+  return Math.ceil(sortedSessions.value.length / sessionsPerPage)
+})
+
+const changePage = (page) => {
+  currentPage.value = page
+}
 
 const selectSession = (sessionId) => {
   realTimeSessionsStore.currentSessionId = sessionId
@@ -38,6 +53,12 @@ async function deleteSession (sessionId) {
       const updatedSessions = { ...obsPortalDataStore.upcomingRealTimeSessions }
       delete updatedSessions[sessionId]
       obsPortalDataStore.upcomingRealTimeSessions = updatedSessions
+
+      // Check if totalPages has changed
+      const newTotalPages = Math.ceil(Object.values(updatedSessions).length / sessionsPerPage)
+      if (currentPage.value > newTotalPages) {
+        currentPage.value = newTotalPages
+      }
     },
     failCallback: (error) => { console.error('API call failed with error', error) }
   })
@@ -56,10 +77,12 @@ onMounted(() => {
       <h3 v-if="sortedSessions.length">Upcoming Bookings</h3>
       <h3 v-else>No Real-Time Sessions Booked</h3>
         <div class="table-summary">
-        <div v-for="session in sortedSessions" :key="session.id">
+        <div v-for="session in paginatedSessions" :key="session.id">
             <div><a @click.prevent="selectSession(session.id)" class="date">{{ formatDateTime(session.start, { year: 'numeric', month: 'long', day: 'numeric' }) }}</a></div><div>{{ formatDateTime(session.start, { hour: 'numeric', minute: 'numeric' }) }}</div>
             <button @click="deleteSession(session.id)" class="deleteButton">x</button>
         </div>
+        <button v-if="sortedSessions.length > 5 && currentPage!=1" @click="changePage(currentPage - 1)">Back</button>
+        <button v-if="sortedSessions.length > 5 && currentPage!=totalPages" @click="changePage(currentPage + 1)">Next</button>
         </div>
         <button class="button red-bg" @click="router.push('/book/realtime')"> Book Slot </button>
     </div>

--- a/src/components/Dashboard/UpcomingBookings.vue
+++ b/src/components/Dashboard/UpcomingBookings.vue
@@ -81,8 +81,8 @@ onMounted(() => {
             <div><a @click.prevent="selectSession(session.id)" class="date">{{ formatDateTime(session.start, { year: 'numeric', month: 'long', day: 'numeric' }) }}</a></div><div>{{ formatDateTime(session.start, { hour: 'numeric', minute: 'numeric' }) }}</div>
             <button @click="deleteSession(session.id)" class="deleteButton">x</button>
         </div>
-        <button v-if="sortedSessions.length > 5 && currentPage!=1" @click="changePage(currentPage - 1)">Back</button>
-        <button v-if="sortedSessions.length > 5 && currentPage!=totalPages" @click="changePage(currentPage + 1)">Next</button>
+        <button v-if="sortedSessions.length > 5 && currentPage!=1" @click="changePage(currentPage - 1)" class="button">Earlier sessions</button>
+        <button v-if="sortedSessions.length > 5 && currentPage!=totalPages" @click="changePage(currentPage + 1)" class="button">Later sessions</button>
         </div>
         <button class="button red-bg" @click="router.push('/book/realtime')"> Book Slot </button>
     </div>

--- a/src/stores/obsPortalData.js
+++ b/src/stores/obsPortalData.js
@@ -18,16 +18,14 @@ export const useObsPortalDataStore = defineStore('obsPortalData', {
   persist: true,
   actions: {
     sortResponseData (response) {
-    // we only want to display observations that are either COMPLETED or REAL_TIME and have ended and since each session lasts 15 minutes, we only want to display sessions that have ended in the last 16 minutes
-      const sixteenMinutes = 16 * 60 * 1000
-      const sessionCutoff = new Date(new Date().getTime() - sixteenMinutes).toISOString()
+      const currentTime = new Date().toISOString()
       for (const result of response.results) {
         const sessionEnd = new Date(result.end).toISOString()
-        if ((result.state === 'COMPLETED') || (result.observation_type === 'REAL_TIME' && sessionEnd < sessionCutoff)) {
+        if ((result.state === 'COMPLETED') || (result.observation_type === 'REAL_TIME' && sessionEnd < currentTime)) {
           if (!this.completedObservations[result.id]) {
             this.completedObservations[result.id] = result
           }
-        } else if (result.observation_type === 'REAL_TIME' && sessionEnd > sessionCutoff) {
+        } else if (result.observation_type === 'REAL_TIME' && sessionEnd > currentTime) {
           if (!this.upcomingRealTimeSessions[result.id]) {
             this.upcomingRealTimeSessions[result.id] = result
           }


### PR DESCRIPTION
## FEATURE: Paginate RTIs

**Background:**
Instead of having a long list of rti sessions, it makes sense to paginate them. For now, I chose to paginate them by 5 but this number can change. Just say the word.

**Implementation:**
Added computed const `paginatedSessions` that takes the value of the `sortedSessions` and slices from `start` (which is initiated as 0) and the end (initiated at 5 - and because it's slice, excludes the 5)
Then we make sure in `deleteSession` that these values are updated so that the rendering and the UX is smooth (see video) 

### VISUALS
**Screen recording of 22 booked sessions. User deletes 1, it bumps up the values, user deletes last one, renders _new_ last page**

https://github.com/user-attachments/assets/2ab1ef58-4593-40f6-8944-45ead1f06730



