### PR TITLE
Update/thumbnail and dashboard display

### DIFF
--- a/src/components/Images/MyGallery.vue
+++ b/src/components/Images/MyGallery.vue
@@ -27,6 +27,7 @@ function closeModal () {
   isModalOpen.value = false
   obsPortalDataStore.setSelectedConfiguration(null)
 }
+// These have to be computed cause they change when the store is updated which is on every page change
 const observations = computed(() => { return obsPortalDataStore.completedObservations })
 const sortedObservations = computed(() => { return Object.values(observations.value).sort((a, b) => new Date(b.start) - new Date(a.start)) })
 

--- a/src/components/Images/MyGallery.vue
+++ b/src/components/Images/MyGallery.vue
@@ -28,8 +28,7 @@ function closeModal () {
   obsPortalDataStore.setSelectedConfiguration(null)
 }
 // These have to be computed cause they change when the store is updated which is on every page change
-const observations = computed(() => { return obsPortalDataStore.completedObservations })
-const sortedObservations = computed(() => { return Object.values(observations.value).sort((a, b) => new Date(b.start) - new Date(a.start)) })
+const observations = obsPortalDataStore.completedObservations
 
 const totalPages = computed(() => {
   return Math.ceil(obsPortalDataStore.completedObservationsCount / pageSize)
@@ -40,7 +39,7 @@ const loadThumbnailsForPage = async (page) => {
   loading.value = true
   await obsPortalDataStore.fetchCompletedObservations(page)
   thumbnailsMap.value = {}
-  for (const obs of Object.values(sortedObservations.value)) {
+  for (const obs of Object.values(observations)) {
     const thumbnails = await getThumbnails('observation_id', obs.id)
     // thumbnailsMap.value[obs.id] = thumbnails
     thumbnailsMap.value[obs.id] = thumbnails.map(thumbnail => ({
@@ -92,7 +91,7 @@ onMounted(() => {
   </template>
   <template v-else>
   <div class="container">
-    <div v-for="obs in sortedObservations" :key="obs.id">
+    <div v-for="obs in observations" :key="obs.id">
       <h3 class="startTime">{{ formatDateTime(obs.start, { year: 'numeric', month: 'long', day: 'numeric' }) }}</h3>
       <div v-if="!thumbnailsMap[obs.id] || thumbnailsMap[obs.id].length === 0">
         <!-- No thumbnails found -->

--- a/src/components/Images/MyGallery.vue
+++ b/src/components/Images/MyGallery.vue
@@ -28,7 +28,7 @@ function closeModal () {
   obsPortalDataStore.setSelectedConfiguration(null)
 }
 // These have to be computed cause they change when the store is updated which is on every page change
-const observations = obsPortalDataStore.completedObservations
+const observations = computed(() => { return obsPortalDataStore.completedObservations })
 
 const totalPages = computed(() => {
   return Math.ceil(obsPortalDataStore.completedObservationsCount / pageSize)
@@ -39,7 +39,7 @@ const loadThumbnailsForPage = async (page) => {
   loading.value = true
   await obsPortalDataStore.fetchCompletedObservations(page)
   thumbnailsMap.value = {}
-  for (const obs of Object.values(observations)) {
+  for (const obs of Object.values(observations.value)) {
     const thumbnails = await getThumbnails('observation_id', obs.id)
     // thumbnailsMap.value[obs.id] = thumbnails
     thumbnailsMap.value[obs.id] = thumbnails.map(thumbnail => ({

--- a/src/stores/obsPortalData.js
+++ b/src/stores/obsPortalData.js
@@ -81,7 +81,6 @@ export const useObsPortalDataStore = defineStore('obsPortalData', {
     },
     storeCompletedObservations (observations) {
       this.completedObservationsCount = observations.count
-      this.completedObservations = {}
       for (const observation of observations.results) {
         this.completedObservations[observation.id] = observation
       }
@@ -98,6 +97,7 @@ export const useObsPortalDataStore = defineStore('obsPortalData', {
         url: configurationStore.observationPortalUrl + `observations/?user=${username}&state=COMPLETED&limit=${limit}&offset=${offset}&ordering=-start`,
         method: 'GET',
         successCallback: (response) => {
+          this.completedObservations = {}
           this.storeCompletedObservations(response)
         }
       })

--- a/src/stores/obsPortalData.js
+++ b/src/stores/obsPortalData.js
@@ -30,9 +30,12 @@ export const useObsPortalDataStore = defineStore('obsPortalData', {
       const configurationStore = useConfigurationStore()
       const userDataStore = useUserDataStore()
       const username = userDataStore.username
+      // I know now why this has to be 16 minutes. If it's `end_after=${now}`, the session only appears on the dashboard before now.
+      // Meaning, the session will not show up in the list if it has already started. So users can't join a session that has already started.
+      // sixteenMinutesFromNow is the time 16 minutes from now in ISO format so they can access the session
       const now = new Date().toISOString()
       await fetchApiCall({
-        url: configurationStore.observationPortalUrl + `observations/?user=${username}&state=PENDING&observation_type=REAL_TIME&limit=100&ordering=-start&end_after=${now}`,
+        url: configurationStore.observationPortalUrl + `observations/?user=${username}&state=PENDING&state=IN_PROGRESS&observation_type=REAL_TIME&limit=100&ordering=-start&end_after=${now}`,
         method: 'GET',
         successCallback: (response) => {
           this.storeUpcomingRealTimeSessions(response)
@@ -79,12 +82,6 @@ export const useObsPortalDataStore = defineStore('obsPortalData', {
         }
       })
     },
-    storeCompletedObservations (observations) {
-      this.completedObservationsCount = observations.count
-      for (const observation of observations.results) {
-        this.completedObservations[observation.id] = observation
-      }
-    },
     async fetchCompletedObservations (page = 1) {
       const configurationStore = useConfigurationStore()
       const userDataStore = useUserDataStore()
@@ -98,7 +95,8 @@ export const useObsPortalDataStore = defineStore('obsPortalData', {
         method: 'GET',
         successCallback: (response) => {
           this.completedObservations = {}
-          this.storeCompletedObservations(response)
+          this.completedObservationsCount = response.count
+          this.completedObservations = response.results
         }
       })
     },

--- a/src/tests/unit/utils/obsPortalDataStore.test.js
+++ b/src/tests/unit/utils/obsPortalDataStore.test.js
@@ -105,7 +105,7 @@ describe('Observation Portal Data Store', () => {
     fetchApiCall.mockImplementationOnce(({ successCallback }) => {
       successCallback(mockAllCompletedObservationsResponse)
     })
-    await obsPortalDataStore.fetchAllCompletedObservations()
+    await obsPortalDataStore.fetchCompletedObservations()
     expect(fetchApiCall).toHaveBeenCalledTimes(1)
     expect(obsPortalDataStore.completedObservations).toEqual({
       789: mockAllCompletedObservationsResponse.results[0],

--- a/src/tests/unit/utils/obsPortalDataStore.test.js
+++ b/src/tests/unit/utils/obsPortalDataStore.test.js
@@ -107,9 +107,9 @@ describe('Observation Portal Data Store', () => {
     })
     await obsPortalDataStore.fetchCompletedObservations()
     expect(fetchApiCall).toHaveBeenCalledTimes(1)
-    expect(obsPortalDataStore.completedObservations).toEqual({
-      789: mockAllCompletedObservationsResponse.results[0],
-      101112: mockAllCompletedObservationsResponse.results[1]
-    })
+    expect(obsPortalDataStore.completedObservations).toEqual([
+      mockAllCompletedObservationsResponse.results[0],
+      mockAllCompletedObservationsResponse.results[1]
+    ])
   })
 })


### PR DESCRIPTION
## UPDATE AND FIX: Dashboard display of thumbnails

**Background:**
We were getting messy data and empty data before the bridge and site software returned a `state` of `COMPLETED` for `REAL_TIME` observations. Now that this is done, it's much easier to fix this issue. And it's fixed!

**Implementation:**
Updated the function `fetchAllCompletedObservations` to `fetchCompletedObservations` and it takes a `page` param which is initiated to `1`. This value changes as the user navigates through pages. This function also declares a few new values that are used for making the request to the observation portal (`limit` & `offset`). This makes it easier to just always make only 5 calls per page and keep the offset correct

I also added conditional rendering so that if the user doesn't have any observations, they see a different view. And if the observation doesn't have thumbnails, then render a message - which can change to some other message. I couldn't come up with something more creative

### VISUALS
**Only 5 api calls per page load**

https://github.com/user-attachments/assets/de1f66ec-7311-47ae-8e51-5351e3e39e2f


**View for a user without observations**
<img width="1216" alt="Screenshot 2025-02-19 at 1 52 26 PM" src="https://github.com/user-attachments/assets/6848e3c1-7f27-4bf2-ba4c-7d1d378fa883" />



