### PR TITLE
Feature: preselected filters and exposure times can now be sent as a command during rti sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "eslint-plugin-vue": "^9.25.0",
         "jsdom": "^25.0.0",
         "vite": "^5.4.3",
-        "vitest": "^2.0.5"
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@achrinza/node-ipc": {
@@ -3263,15 +3263,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.1.tgz",
-      "integrity": "sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.1",
-        "@vitest/utils": "2.1.1",
-        "chai": "^5.1.1",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
         "tinyrainbow": "^1.2.0"
       },
       "funding": {
@@ -3279,21 +3279,21 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.1.tgz",
-      "integrity": "sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "^2.1.0-beta.1",
+        "@vitest/spy": "2.1.9",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.11"
+        "magic-string": "^0.30.12"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/spy": "2.1.1",
-        "msw": "^2.3.5",
+        "msw": "^2.4.9",
         "vite": "^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -3316,9 +3316,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.4.tgz",
-      "integrity": "sha512-L95zIAkEuTDbUX1IsjRl+vyBSLh3PwLLgKpghl37aCK9Jvw0iP+wKwIFhfjdUtA2myLgjrG6VU6JCFLv8q/3Ww==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3329,13 +3329,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.1.tgz",
-      "integrity": "sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.1",
+        "@vitest/utils": "2.1.9",
         "pathe": "^1.1.2"
       },
       "funding": {
@@ -3343,37 +3343,24 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.1.tgz",
-      "integrity": "sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.1",
-        "magic-string": "^0.30.11",
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
         "pathe": "^1.1.2"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.1.tgz",
-      "integrity": "sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/@vitest/spy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.1.tgz",
-      "integrity": "sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3384,27 +3371,14 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.1.tgz",
-      "integrity": "sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.1",
-        "loupe": "^3.1.1",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.1.tgz",
-      "integrity": "sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
         "tinyrainbow": "^1.2.0"
       },
       "funding": {
@@ -5282,9 +5256,9 @@
       }
     },
     "node_modules/chai": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
-      "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7884,6 +7858,16 @@
         "which": "bin/which"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
+      "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.21.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
@@ -10341,9 +10325,9 @@
       }
     },
     "node_modules/loupe": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
-      "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
       "dev": true,
       "license": "MIT"
     },
@@ -13641,9 +13625,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
-      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
+      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -14114,10 +14098,11 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.0.tgz",
-      "integrity": "sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==",
-      "dev": true
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinypool": {
       "version": "1.0.1",
@@ -14666,14 +14651,15 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.1.tgz",
-      "integrity": "sha512-N/mGckI1suG/5wQI35XeR9rsMsPqKXzq1CdUndzVstBj/HvyxxGctwnK6WX43NGt5L3Z5tcRf83g4TITKJhPrA==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.3.6",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
         "pathe": "^1.1.2",
         "vite": "^5.0.0"
       },
@@ -14688,30 +14674,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.1.tgz",
-      "integrity": "sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "2.1.1",
-        "@vitest/mocker": "2.1.1",
-        "@vitest/pretty-format": "^2.1.1",
-        "@vitest/runner": "2.1.1",
-        "@vitest/snapshot": "2.1.1",
-        "@vitest/spy": "2.1.1",
-        "@vitest/utils": "2.1.1",
-        "chai": "^5.1.1",
-        "debug": "^4.3.6",
-        "magic-string": "^0.30.11",
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
         "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
+        "std-env": "^3.8.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.0",
-        "tinypool": "^1.0.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
         "tinyrainbow": "^1.2.0",
         "vite": "^5.0.0",
-        "vite-node": "2.1.1",
+        "vite-node": "2.1.9",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -14726,8 +14713,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.1",
-        "@vitest/ui": "2.1.1",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-vue": "^9.25.0",
     "jsdom": "^25.0.0",
     "vite": "^5.4.3",
-    "vitest": "^2.0.5"
+    "vitest": "^2.1.9"
   },
   "eslintConfig": {
     "root": true,

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -97,9 +97,9 @@ function setRaDecfromTargetList (event) {
     targetName.value = selectedTarget.value.name
     suggestionTargetSet.value = true
     goToLocation()
-    exposureTime.value = selectedTarget.value.filters.map(f => f.exposure)
     exposureCount.value = 1
-    selectedFilter.value = selectedTarget.value.filters.map(f => f.name)
+    exposureTime.value = Object.values(selectedTarget.value.filters).map(f => f.exposure)
+    selectedFilter.value = Object.values(selectedTarget.value.filters).map(f => f.name)
   }
 }
 
@@ -146,8 +146,8 @@ const sendGoCommand = async () => {
   // If suggestions mode is selected, then selectedFilter and exposureTime are populated with the values from the selected target
   // If manual mode is selected, then selectedFilter and exposureTime are populated with the values entered by the user
   // The fill method is used to repeat the values for each exposure in the sequence as many times as the value of exposureCount
-  const exposFilter = suggestionOrManual.value === 'suggestions' ? Object.values(selectedFilter.value) : Array(exposureCount.value).fill(selectedFilter.value)
-  const exposTime = suggestionOrManual.value === 'suggestions' ? Object.values(exposureTime.value) : Array(exposureCount.value).fill(Number(exposureTime.value))
+  const exposFilter = suggestionOrManual.value === 'suggestions' ? selectedFilter.value : Array(exposureCount.value).fill(selectedFilter.value)
+  const exposTime = suggestionOrManual.value === 'suggestions' ? exposureTime.value : Array(exposureCount.value).fill(Number(exposureTime.value))
   const requestBody = {
     dec: Number(dec.value),
     expFilter: exposFilter,

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -291,6 +291,9 @@ onMounted(async () => {
                   <h3>{{ selectedTarget.name }}</h3>
                   <p><strong>Type:</strong> {{ selectedTarget.avmdesc }}</p>
                   <p>{{  selectedTarget.desc }}</p>
+                  <p><strong>Exposure settings:</strong></p>
+                    <!-- eslint-disable-next-line vue/require-v-for-key -->
+                    <div v-for="filter in selectedTarget.filters">{{ filter.name }} filter for {{ filter.exposure }} seconds </div>
                 </div>
             </div>
           </div>

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -146,8 +146,10 @@ const sendGoCommand = async () => {
   const exposTime = Array(exposureCount.value).fill(Number(exposureTime.value))
   const requestBody = {
     dec: Number(dec.value),
-    expFilter: exposFilter,
-    expTime: exposTime,
+    // expFilter: exposFilter,
+    expFilter: ['rp', 'gp', 'ip'],
+    expTime: [5, 5, 5],
+    // expTime: exposTime,
     // Name is the target name if entered, else the coordinates in string format
     name: targetName.value || `${(Number(raValue.value).toFixed(4)).toString()}_${(Number(decValue.value).toFixed(4)).toString()}`,
     ra: Number(ra.value) / 15,
@@ -156,6 +158,7 @@ const sendGoCommand = async () => {
     requestId: realTimeSessionsStore.currentSession.request.id,
     observationId: realTimeSessionsStore.currentSession.id
   }
+  console.log('request body', requestBody)
   if (configurationStore.demo == true) {
     loading.value = false
     resetValues()

--- a/src/tests/unit/utils/obsPortalDataStore.test.js
+++ b/src/tests/unit/utils/obsPortalDataStore.test.js
@@ -107,9 +107,9 @@ describe('Observation Portal Data Store', () => {
     })
     await obsPortalDataStore.fetchCompletedObservations()
     expect(fetchApiCall).toHaveBeenCalledTimes(1)
-    expect(obsPortalDataStore.completedObservations).toEqual({
-      789: mockAllCompletedObservationsResponse.results[0],
-      101112: mockAllCompletedObservationsResponse.results[1]
-    })
+    expect(obsPortalDataStore.completedObservations).toEqual([
+      mockAllCompletedObservationsResponse.results[0],
+      mockAllCompletedObservationsResponse.results[1]
+    ])
   })
 })


### PR DESCRIPTION
## Feature: Preselected filters and exposure times can now be sent as a command during rti sessions

**Background:**
With the new feature of suggested targets comes suggested exposure settings (which currently cannot be changed). These settings can come in groups of 3. The `sendGoCommand` wasn't equipped for that, so now I've made a few tweaks so that this works.

**Implementation:**
In `setRaDecfromTargetList` I've changed the values of `exposureTime` and `selectedFilter` to be an array of all the suggestions rather than just the first one. 
Then, in `sendGoCommand`, I check for the values of `suggestionOrManual` and if it's `suggestions` then we send those values to the bridge as an array. 

### VISUALS
**The console shows what the request body looks like**

https://github.com/user-attachments/assets/34f0d0ed-c8a6-4d31-90d0-ed1a7aa7b3ae

