### PR TITLE
Fix/login username

### DIFF
--- a/src/components/LogIn/LogIn.vue
+++ b/src/components/LogIn/LogIn.vue
@@ -24,7 +24,7 @@ const storeAPIToken = async (data) => {
 }
 
 const storeUser = (user) => {
-  userDataStore.username = username.value
+  userDataStore.username = user.username
   userDataStore.profile = user
   router.push('/dashboard')
 }


### PR DESCRIPTION
If the user entered their email to log in, then the username was the email. This is no longer the case. Now it doesn't matter if the user logs in with email or username, the username comes from the profile response