### PR TITLE
Fix/proposal display

### DIFF
--- a/src/components/Global/ProposalDropdown.vue
+++ b/src/components/Global/ProposalDropdown.vue
@@ -14,13 +14,12 @@ const props = defineProps({
 const proposalStore = useProposalStore()
 const selectedProposal = ref()
 const proposals = ref([])
-const allActiveProposals = computed(() => { return proposalStore.allActiveProposals })
 
 // If the user is requesting a real-time observation, only show proposals with real-time allocations
 // If the user is requesting a normal-time observation, only show proposals with normal time allocations
 const sortProposalDropdownSelection = () => {
   if (props.isItRealTime) {
-    proposals.value = proposalStore.allActiveProposals
+    proposals.value = proposalStore.proposalsWithRealTimeAllocation
   } else if (!props.isItRealTime) {
     proposals.value = proposalStore.proposalsWithNormalTimeAllocation
   }
@@ -33,7 +32,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <template v-if="allActiveProposals">
+  <template v-if="proposals.length > 0">
     <div class="field">
       <label for="proposalSelect">Select the project you would like to use</label>
         <div class="control">
@@ -51,7 +50,7 @@ onMounted(() => {
       </div>
     </div>
   </template>
-  <template v-else-if="!allActiveProposals">
+  <template v-else-if="!proposals.length">
     <div>
       <p>No proposals found. Please create a proposal <a href="https://observe.lco.global/apply">here</a></p>
     </div>

--- a/src/components/Global/ProposalDropdown.vue
+++ b/src/components/Global/ProposalDropdown.vue
@@ -32,6 +32,7 @@ onMounted(() => {
 </script>
 
 <template>
+  <!-- Only rendering if there is more than one proposal, otherwise it's automatically selected -->
   <template v-if="proposals.length > 1">
     <div class="field">
       <label for="proposalSelect">Select the project you would like to use</label>

--- a/src/components/Global/ProposalDropdown.vue
+++ b/src/components/Global/ProposalDropdown.vue
@@ -32,7 +32,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <template v-if="proposals.length > 0">
+  <template v-if="proposals.length > 1">
     <div class="field">
       <label for="proposalSelect">Select the project you would like to use</label>
         <div class="control">

--- a/src/components/Global/ProposalDropdown.vue
+++ b/src/components/Global/ProposalDropdown.vue
@@ -1,15 +1,20 @@
 <script setup>
-import { ref, defineEmits } from 'vue'
-import { useUserDataStore } from '../../stores/userData'
+import { ref, defineEmits, onMounted, computed } from 'vue'
+import { useProposalStore } from '../../stores/proposalManagement.js'
+
 const emit = defineEmits(['selectionsComplete'])
-const userDataStore = useUserDataStore()
-const proposals = userDataStore.profile.proposals
-const activeProposals = proposals.filter(proposal => proposal.current === true)
+const proposalStore = useProposalStore()
 const selectedProposal = ref()
+const moreThanOneProposalWithRealTimeAllocation = computed(() => proposalStore.proposalsWithRealTimeAllocation)
+const allActiveProposals = computed(() => proposalStore.allActiveProposals)
+
+onMounted(() => {
+  console.log('all active proposals', allActiveProposals.value)
+})
 </script>
 
 <template>
-  <template v-if="proposals.length">
+  <template v-if="moreThanOneProposalWithRealTimeAllocation || allActiveProposals.length > 0">
     <div class="field">
       <label for="proposalSelect">Select the project you would like to use</label>
         <div class="control">
@@ -19,15 +24,15 @@ const selectedProposal = ref()
             v-model="selectedProposal"
             @change="emit('selectionsComplete', selectedProposal)"
             >
-            <option v-for="proposal in activeProposals" :key="proposal.id" :value="proposal.id">
+            <option v-for="proposal in allActiveProposals" :key="proposal.id" :value="proposal.id">
                 {{ proposal.title }}
-              </option>
+            </option>
         </select>
         </div>
       </div>
     </div>
   </template>
-  <template v-else>
+  <template v-else-if="!allActiveProposals">
     <div>
       <p>No proposals found. Please create a proposal <a href="https://observe.lco.global/apply">here</a></p>
     </div>

--- a/src/components/Global/ProposalDropdown.vue
+++ b/src/components/Global/ProposalDropdown.vue
@@ -1,16 +1,39 @@
 <script setup>
-import { ref, defineEmits, onMounted, computed } from 'vue'
+import { ref, defineEmits, computed, defineProps, onMounted } from 'vue'
 import { useProposalStore } from '../../stores/proposalManagement.js'
 
 const emit = defineEmits(['selectionsComplete'])
+
+const props = defineProps({
+  isItRealTime: {
+    type: Boolean,
+    required: true
+  }
+})
+
 const proposalStore = useProposalStore()
 const selectedProposal = ref()
+const proposals = ref([])
 const allActiveProposals = computed(() => { return proposalStore.allActiveProposals })
+
+// If the user is requesting a real-time observation, only show proposals with real-time allocations
+// If the user is requesting a normal-time observation, only show proposals with normal time allocations
+const sortProposalDropdownSelection = () => {
+  if (props.isItRealTime) {
+    proposals.value = proposalStore.allActiveProposals
+  } else if (!props.isItRealTime) {
+    proposals.value = proposalStore.proposalsWithNormalTimeAllocation
+  }
+}
+
+onMounted(() => {
+  sortProposalDropdownSelection()
+})
 
 </script>
 
 <template>
-  <template v-if="allActiveProposals.length > 0">
+  <template v-if="allActiveProposals">
     <div class="field">
       <label for="proposalSelect">Select the project you would like to use</label>
         <div class="control">
@@ -20,7 +43,7 @@ const allActiveProposals = computed(() => { return proposalStore.allActivePropos
             v-model="selectedProposal"
             @change="emit('selectionsComplete', selectedProposal)"
             >
-            <option v-for="proposal of allActiveProposals" :key="proposal.id" :value="proposal.id">
+            <option v-for="proposal of proposals" :key="proposal.id" :value="proposal.id">
               {{ proposal.title }}
             </option>
         </select>

--- a/src/components/Global/ProposalDropdown.vue
+++ b/src/components/Global/ProposalDropdown.vue
@@ -5,16 +5,12 @@ import { useProposalStore } from '../../stores/proposalManagement.js'
 const emit = defineEmits(['selectionsComplete'])
 const proposalStore = useProposalStore()
 const selectedProposal = ref()
-const moreThanOneProposalWithRealTimeAllocation = computed(() => proposalStore.proposalsWithRealTimeAllocation)
-const allActiveProposals = computed(() => proposalStore.allActiveProposals)
+const allActiveProposals = computed(() => { return proposalStore.allActiveProposals })
 
-onMounted(() => {
-  console.log('all active proposals', allActiveProposals.value)
-})
 </script>
 
 <template>
-  <template v-if="moreThanOneProposalWithRealTimeAllocation || allActiveProposals.length > 0">
+  <template v-if="allActiveProposals.length > 0">
     <div class="field">
       <label for="proposalSelect">Select the project you would like to use</label>
         <div class="control">
@@ -24,8 +20,8 @@ onMounted(() => {
             v-model="selectedProposal"
             @change="emit('selectionsComplete', selectedProposal)"
             >
-            <option v-for="proposal in allActiveProposals" :key="proposal.id" :value="proposal.id">
-                {{ proposal.title }}
+            <option v-for="proposal of allActiveProposals" :key="proposal.id" :value="proposal.id">
+              {{ proposal.title }}
             </option>
         </select>
         </div>

--- a/src/components/RealTimeInterface/TimePicker.vue
+++ b/src/components/RealTimeInterface/TimePicker.vue
@@ -5,12 +5,18 @@ import { useRealTimeSessionsStore } from '../../stores/realTimeSessions'
 import { fetchApiCall } from '../../utils/api'
 import { formatToUTC, formatDateTime } from '../../utils/formatTime.js'
 import { useConfigurationStore } from '../../stores/configuration'
+
+import { useProposalStore } from '../../stores/proposalManagement.js'
+
 import LeafletMap from './GlobeMap/LeafletMap.vue'
 import ProposalDropdown from '../Global/ProposalDropdown.vue'
 import sites from '../../utils/sites.JSON'
+
 const router = useRouter()
 const realTimeSessionsStore = useRealTimeSessionsStore()
 const configurationStore = useConfigurationStore()
+const proposalStore = useProposalStore()
+
 const date = ref(null)
 const startTime = ref(null)
 const errorMessage = ref(null)
@@ -245,6 +251,11 @@ watch(startTime, (newTime, oldTime) => {
 })
 onMounted(() => {
   getAvailableTimes()
+  proposalStore.fetchProposals().then(() => {
+    if (proposalStore.proposalsWithRealTimeAllocation.length === 1) {
+      selectedProposal.value = proposalStore.proposalsWithRealTimeAllocation[0].id
+    }
+  })
 })
 </script>
 <template>
@@ -253,7 +264,7 @@ onMounted(() => {
   </template>
   <template v-if="hasAvailableTimes">
     <h2>Book your live observing session</h2>
-    <ProposalDropdown @selectionsComplete="(proposal) => { selectedProposal = proposal }" />
+    <ProposalDropdown v-if="!selectedProposal" @selectionsComplete="(proposal) => { selectedProposal.value = proposal }" />
     <div class="columns">
       <div v-if="selectedProposal" class="column is-one-third">
         <p>Select a date and time:</p>

--- a/src/components/RealTimeInterface/TimePicker.vue
+++ b/src/components/RealTimeInterface/TimePicker.vue
@@ -249,9 +249,9 @@ watch(startTime, (newTime, oldTime) => {
     emits('timeSelected', newTime)
   }
 })
-onMounted(() => {
+onMounted(async () => {
   getAvailableTimes()
-  proposalStore.fetchProposals().then(() => {
+  await proposalStore.fetchProposals().then(() => {
     if (proposalStore.proposalsWithRealTimeAllocation.length === 1) {
       selectedProposal.value = proposalStore.proposalsWithRealTimeAllocation[0].id
     }

--- a/src/components/RealTimeInterface/TimePicker.vue
+++ b/src/components/RealTimeInterface/TimePicker.vue
@@ -264,7 +264,7 @@ onMounted(() => {
   </template>
   <template v-if="hasAvailableTimes">
     <h2>Book your live observing session</h2>
-    <ProposalDropdown v-if="!selectedProposal" @selectionsComplete="(proposal) => { selectedProposal.value = proposal }" />
+    <ProposalDropdown v-if="!selectedProposal" :isItRealTime="true" @selectionsComplete="(proposal) => { selectedProposal.value = proposal }" />
     <div class="columns">
       <div v-if="selectedProposal" class="column is-one-third">
         <p>Select a date and time:</p>

--- a/src/components/Scheduling/AdvancedScheduling.vue
+++ b/src/components/Scheduling/AdvancedScheduling.vue
@@ -55,6 +55,10 @@ const emitSelections = () => {
   }
 }
 
+const hasManyProposals = () => {
+  return proposalStore.proposalsWithNormalTimeAllocation.length > 1
+}
+
 onMounted(() => {
   if (proposalStore.proposalsWithNormalTimeAllocation.length === 1) {
     selectedProposal.value = proposalStore.proposalsWithRealTimeAllocation[0].id
@@ -71,7 +75,7 @@ onMounted(() => {
     @targetUpdated="handleTargetUpdate"
     @exposuresUpdated="handleExposuresUpdate"
   />
-  <ProposalDropdown :isItRealTime="false" @selectionsComplete="(proposal) => { selectedProposal = proposal }"/>
+  <ProposalDropdown v-if="hasManyProposals" :isItRealTime="false" @selectionsComplete="(proposal) => { selectedProposal = proposal }"/>
   <Calendar @updateDateRange="handleDateRangeUpdate" />
 </template>
 

--- a/src/components/Scheduling/AdvancedScheduling.vue
+++ b/src/components/Scheduling/AdvancedScheduling.vue
@@ -62,7 +62,7 @@ const emitSelections = () => {
     @targetUpdated="handleTargetUpdate"
     @exposuresUpdated="handleExposuresUpdate"
   />
-  <ProposalDropdown @selectionsComplete="(proposal) => { selectedProposal = proposal }"/>
+  <ProposalDropdown :isItRealTime="false" @selectionsComplete="(proposal) => { selectedProposal = proposal }"/>
   <Calendar @updateDateRange="handleDateRangeUpdate" />
 </template>
 

--- a/src/components/Scheduling/AdvancedScheduling.vue
+++ b/src/components/Scheduling/AdvancedScheduling.vue
@@ -1,8 +1,11 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import SchedulingSettings from './SchedulingSettings.vue'
 import ProposalDropdown from '../Global/ProposalDropdown.vue'
 import Calendar from './Calendar.vue'
+import { useProposalStore } from '../../stores/proposalManagement.js'
+
+const proposalStore = useProposalStore()
 
 const targetsData = ref([])
 const startDate = ref('')
@@ -51,6 +54,12 @@ const emitSelections = () => {
     })
   }
 }
+
+onMounted(() => {
+  if (proposalStore.proposalsWithNormalTimeAllocation.length === 1) {
+    selectedProposal.value = proposalStore.proposalsWithRealTimeAllocation[0].id
+  }
+})
 </script>
 
 <template>

--- a/src/components/Scheduling/BeginnerScheduling.vue
+++ b/src/components/Scheduling/BeginnerScheduling.vue
@@ -262,7 +262,7 @@ const handleExposuresUpdate = (exposures) => {
   </template>
   <div class="container">
     <div v-if="!dateRange || currentStep === 1">
-      <ProposalDropdown @selectionsComplete="(proposal) => { selectedProposal = proposal; nextStep() }" />
+      <ProposalDropdown :isItRealTime="false" @selectionsComplete="(proposal) => { selectedProposal = proposal; nextStep() }" />
     </div>
     <Calendar v-if="selectedProposal && currentStep === 2" @updateDateRange="handleDateRangeUpdate" />
     <div v-if="currentStep === 3 && categories && categories.length > 0" class="content">

--- a/src/components/Scheduling/BeginnerScheduling.vue
+++ b/src/components/Scheduling/BeginnerScheduling.vue
@@ -256,6 +256,10 @@ const handleExposuresUpdate = (exposures) => {
   emitSelections()
 }
 
+const hasManyProposals = () => {
+  return proposalStore.proposalsWithNormalTimeAllocation.length > 1
+}
+
 onMounted(() => {
   if (proposalStore.proposalsWithNormalTimeAllocation.length === 1) {
     selectedProposal.value = proposalStore.proposalsWithRealTimeAllocation[0].id
@@ -270,7 +274,7 @@ onMounted(() => {
   </template>
   <div class="container">
     <div v-if="!dateRange || currentStep === 1">
-      <ProposalDropdown :isItRealTime="false" @selectionsComplete="(proposal) => { selectedProposal = proposal; nextStep() }" />
+      <ProposalDropdown v-if="hasManyProposals" :isItRealTime="false" @selectionsComplete="(proposal) => { selectedProposal = proposal; nextStep() }" />
     </div>
     <Calendar v-if="selectedProposal && currentStep === 2" @updateDateRange="handleDateRangeUpdate" />
     <div v-if="currentStep === 3 && categories && categories.length > 0" class="content">

--- a/src/components/Scheduling/BeginnerScheduling.vue
+++ b/src/components/Scheduling/BeginnerScheduling.vue
@@ -1,12 +1,14 @@
 <script setup>
-import { ref, defineEmits } from 'vue'
+import { ref, defineEmits, onMounted } from 'vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import Calendar from './Calendar.vue'
 import SchedulingSettings from './SchedulingSettings.vue'
 import ProposalDropdown from '../Global/ProposalDropdown.vue'
 import { fetchApiCall } from '../../utils/api.js'
+import { useProposalStore } from '../../stores/proposalManagement.js'
 
 const emits = defineEmits(['selectionsComplete', 'showButton'])
+const proposalStore = useProposalStore()
 
 const beginner = ref()
 const dateRange = ref()
@@ -253,6 +255,12 @@ const handleExposuresUpdate = (exposures) => {
   exposureSettings.value = exposures
   emitSelections()
 }
+
+onMounted(() => {
+  if (proposalStore.proposalsWithNormalTimeAllocation.length === 1) {
+    selectedProposal.value = proposalStore.proposalsWithRealTimeAllocation[0].id
+  }
+})
 
 </script>
 

--- a/src/components/Views/SchedulingView.vue
+++ b/src/components/Views/SchedulingView.vue
@@ -1,11 +1,13 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 import AdvancedScheduling from '../Scheduling/AdvancedScheduling.vue'
 import BeginnerScheduling from '../Scheduling/BeginnerScheduling.vue'
 import ScheduledObservations from '../Scheduling/ScheduledObservations.vue'
 import { fetchApiCall } from '../../utils/api.js'
 import { formatToUTC } from '../../utils/formatTime'
+import { useProposalStore } from '../../stores/proposalManagement.js'
 
+const proposalStore = useProposalStore()
 // TO DO (future): Get level depending on course completion
 const level = ref('')
 const observationData = ref(null)
@@ -53,7 +55,7 @@ const createRequest = (target, exposures, startDate, endDate) => ({
       'target': {
         'name': target.name,
         'type': 'ICRS',
-        'ra': target.ra,
+        'ra': Number(target.ra) / 15,
         'dec': target.dec,
         'proper_motion_ra': null,
         'proper_motion_dec': null,
@@ -129,6 +131,10 @@ const handleUserSelections = (data) => {
 
 const enableButton = computed(() => {
   return observationData.value && observationData.value.settings.length > 0
+})
+
+onMounted(async () => {
+  await proposalStore.fetchProposals()
 })
 
 </script>

--- a/src/stores/proposalManagement.js
+++ b/src/stores/proposalManagement.js
@@ -1,0 +1,52 @@
+import { defineStore } from 'pinia'
+import { fetchApiCall } from '../utils/api'
+import { useUserDataStore } from './userData'
+import { useConfigurationStore } from './configuration'
+
+export const useProposalStore = defineStore('proposalManagement', {
+  state () {
+    return {
+      proposalsWithRealTimeAllocation: [],
+      allActiveProposals: []
+    }
+  },
+  persist: true,
+  getters: {
+    getProposalsWithRealTimeAllocation () {
+      return this.proposalsWithRealTimeAllocation
+    },
+    getAllActiveProposals () {
+      return this.allActiveProposals
+    }
+  },
+  actions: {
+    sortProposals (proposals) {
+      this.allActiveProposals = []
+      this.proposalsWithRealTimeAllocation = []
+
+      const activeProposals = proposals.filter(proposal => proposal.current === true)
+      this.allActiveProposals.push(activeProposals)
+      for (const proposal of activeProposals) {
+        // Check if the proposal has any realtime allocation with available credit
+        const hasRealTimeAllocation = proposal.time_allocations.some(time => {
+          const realTimeAllocation = time.realtime_allocation
+          const realTimeUsed = time.realtime_time_used
+          return realTimeAllocation - realTimeUsed > 0
+        })
+        if (hasRealTimeAllocation) {
+          this.proposalsWithRealTimeAllocation.push(proposal)
+        }
+      }
+    },
+    async fetchProposals () {
+      const configurationStore = useConfigurationStore()
+      await fetchApiCall({
+        url: `${configurationStore.observationPortalUrl}profile/?include_current_time_allocations`,
+        method: 'GET',
+        successCallback: (response) => {
+          this.sortProposals(response.proposals)
+        }
+      })
+    }
+  }
+})

--- a/src/stores/proposalManagement.js
+++ b/src/stores/proposalManagement.js
@@ -11,14 +11,6 @@ export const useProposalStore = defineStore('proposalManagement', {
     }
   },
   persist: true,
-  getters: {
-    getProposalsWithRealTimeAllocation () {
-      return this.proposalsWithRealTimeAllocation
-    },
-    getAllActiveProposals () {
-      return this.allActiveProposals
-    }
-  },
   actions: {
     sortProposals (proposals) {
       this.allActiveProposals = []

--- a/src/stores/proposalManagement.js
+++ b/src/stores/proposalManagement.js
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
 import { fetchApiCall } from '../utils/api'
-import { useUserDataStore } from './userData'
 import { useConfigurationStore } from './configuration'
 
 export const useProposalStore = defineStore('proposalManagement', {
@@ -25,7 +24,7 @@ export const useProposalStore = defineStore('proposalManagement', {
       this.proposalsWithRealTimeAllocation = []
 
       const activeProposals = proposals.filter(proposal => proposal.current === true)
-      this.allActiveProposals.push(activeProposals)
+      this.allActiveProposals = activeProposals
       for (const proposal of activeProposals) {
         // Check if the proposal has any realtime allocation with available credit
         const hasRealTimeAllocation = proposal.time_allocations.some(time => {

--- a/src/stores/proposalManagement.js
+++ b/src/stores/proposalManagement.js
@@ -6,6 +6,7 @@ export const useProposalStore = defineStore('proposalManagement', {
   state () {
     return {
       proposalsWithRealTimeAllocation: [],
+      proposalsWithNormalTimeAllocation: [],
       allActiveProposals: []
     }
   },
@@ -22,6 +23,7 @@ export const useProposalStore = defineStore('proposalManagement', {
     sortProposals (proposals) {
       this.allActiveProposals = []
       this.proposalsWithRealTimeAllocation = []
+      this.proposalsWithNormalTimeAllocation = []
 
       const activeProposals = proposals.filter(proposal => proposal.current === true)
       this.allActiveProposals = activeProposals
@@ -32,8 +34,16 @@ export const useProposalStore = defineStore('proposalManagement', {
           const realTimeUsed = time.realtime_time_used
           return realTimeAllocation - realTimeUsed > 0
         })
+        const hasNormalTimeAllocation = proposal.time_allocations.some(time => {
+          const normalTimeAllocation = time.std_allocation
+          const normalTimeUsed = time.std_time_used
+          return normalTimeAllocation - normalTimeUsed > 0
+        })
         if (hasRealTimeAllocation) {
           this.proposalsWithRealTimeAllocation.push(proposal)
+        }
+        if (hasNormalTimeAllocation) {
+          this.proposalsWithNormalTimeAllocation.push(proposal)
         }
       }
     },


### PR DESCRIPTION
## FIX: Proposal Dropdown Selection - refined

**Background:**
The `ProposalDropdown` component was working fine, but now there is a proposal management store to sort proposals with real time allocated and normal time allocated. This way, if users have more than one proposal with different types of time allocated, the possibility of making a request for, say, a real time session with a proposal that doesn't have real time allocated is null. Additionally, if there is only one proposal with valid allocated time for what the user is trying to book, it will select that proposal without rendering the drop down.

**Implementation:**
Added a store to fetch and sort proposals. `fetchProposals` is called on mount of the `TimePicker` component and `SchedulingView` because both eventually load `ProposalDropdown`. 
Props are passed every time `ProposalDropdown` is rendered. Based on the props (true or false), then the adequate proposals are presented as options.

### VISUALS
**There is only one real time proposal, so that one is selected and the drop down doesn't render. Normal time proposals are 2 and those render**

https://github.com/user-attachments/assets/0793176a-6c41-4c9e-b326-49f7bdce1417

