### PR TITLE
renames name of live observing request

### DIFF
--- a/src/components/RealTimeInterface/TimePicker.vue
+++ b/src/components/RealTimeInterface/TimePicker.vue
@@ -169,7 +169,7 @@ const blockRti = async () => {
   }
   const requestBody = {
     proposal: selectedProposal.value,
-    name: 'Live Observing',
+    name: `Live-${startDateTime.toISOString().split('T')[0].replace(/-/g, '')}-${selectedSite.value.site}`,
     site: selectedSite.value.site,
     enclosure,
     telescope,


### PR DESCRIPTION
Renames request when user books a real time session. It was 'Live observing' and now it's 'Live-YYYYMMDD-site'

<img width="348" alt="Screenshot 2025-04-14 at 4 37 07 PM" src="https://github.com/user-attachments/assets/83eb784a-8afc-4789-a4df-e413114057d7" />
