### PR TITLE
displays error for when exposure time exceeds time remaining in session

### DIFF
--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -222,6 +222,8 @@ function resetSuggestionOrManual () {
   suggestionByType.value = ''
   targetsByType.value = []
   suggestionTargetSet.value = false
+  exposureError.value = ''
+  isExposureTimeValid.value = true
 }
 
 function updateRenderGallery (value) {
@@ -476,7 +478,6 @@ watch(
                   <p class="control is-expanded">
                     <input id="exposureTime" type="number" class="input" v-model="exposureTime" placeholder="Seconds">
                   </p>
-                  <p class="help is-danger" v-if="!isExposureTimeValid">{{ exposureError }}</p>
                 </div>
                 <div class="times">
                   <FontAwesomeIcon icon="fa-solid fa-xmark"  />
@@ -490,6 +491,7 @@ watch(
             </div>
           </div>
         </div>
+        <p class="help is-danger" v-if="!isExposureTimeValid">{{ exposureError }}</p>
         <div class="buttons are-medium" v-if="suggestionOrManual != ''">
           <button :disabled="incompleteSelection" class="button red-bg" @click="sendGoCommand()">Go</button>
           <button class="button" @click="resetSuggestionOrManual">Start Again</button>


### PR DESCRIPTION
##FIX: Error display when user selects suggestion and time remaining < exposure time

Just moved values around and when user clicks on "start again" the error values go back to null
<img width="1183" alt="Screenshot 2025-04-15 at 10 23 25 AM" src="https://github.com/user-attachments/assets/fa5e1c42-8d77-4da1-b242-215f9ee40aaf" />
<img width="1151" alt="Screenshot 2025-04-15 at 10 23 53 AM" src="https://github.com/user-attachments/assets/a12fe499-c3bd-4161-8bd0-4bdf76f7d51d" />
