### PR TITLE
Update/rti scheduling view

### DIFF
--- a/src/components/RealTimeInterface/GlobeMap/LeafletMap.vue
+++ b/src/components/RealTimeInterface/GlobeMap/LeafletMap.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, watch, defineEmits, defineProps } from 'vue'
+import { ref, onMounted, defineProps, watch } from 'vue'
 import sites from '../../../utils/sites.JSON'
 import availableIcon from '../../../assets/Icons/available_mapmarker.png'
 import unavailableIcon from '../../../assets/Icons/unavailable_mapmarker.png'
@@ -14,75 +14,42 @@ const props = defineProps({
   selectedTime: {
     type: String,
     required: true
+  },
+  highlightedSite: {
+    type: String,
+    required: false
   }
 })
-
-const emits = defineEmits(['siteSelected'])
 
 const mapContainer = ref(null)
-
-const createIcon = (iconUrl) => {
-  return L.icon({
-    iconUrl,
-    iconSize: [30, 42],
-    iconAnchor: [15, 42],
-    popupAnchor: [0, -42]
-  })
-}
-
-// Updates markers on the map based on the available times and selected time
-const updateMarkers = (map) => {
-  const selectedTime = new Date(props.selectedTime)
-  const availableSites = []
-
-  // Iterates over the available times
-  Object.keys(props.availableTimes).forEach(dateKey => {
-    Object.keys(props.availableTimes[dateKey]).forEach(timeKey => {
-      // Converts the time key to a Date object for comparison
-      const intervalTime = new Date(timeKey)
-
-      // Checks if the time interval matches the selected time
-      if (intervalTime.getTime() === selectedTime.getTime()) {
-        // Adds the resources' sites to the available sites array
-        props.availableTimes[dateKey][timeKey].resources.forEach(resource => {
-          availableSites.push(resource.site)
-        })
-      }
-    })
-  })
-
-  // Iterates over all sites and updates markers on the map
-  Object.entries(sites).forEach(([site, { lat, lon }]) => {
-    const available = availableSites.includes(site)
-    const icon = available ? createIcon(availableIcon) : createIcon(unavailableIcon)
-    const popupText = available ? `${site}<br>available` : `${site}<br>unavailable`
-
-    const marker = L.marker([lat, lon], { icon })
-    marker.bindPopup(popupText)
-    marker.on('click', () => {
-      if (available) {
-        emits('siteSelected', { site, lat, lon })
-      }
-    })
-    marker.addTo(map)
-  })
-}
-
-// Updates the markers when the available times or selected time change
-watch(() => [props.availableTimes, props.selectedTime], () => {
-  if (mapContainer.value) {
-    const map = L.map(mapContainer.value).setView([0, 0], 2)
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {}).addTo(map)
-    updateMarkers(map)
-  }
-}, { immediate: true })
+const map = ref(null)
+const markersLayer = ref(null)
 
 onMounted(() => {
-  const map = L.map(mapContainer.value).setView([0, 0], 2)
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {}).addTo(map)
-
-  updateMarkers(map)
+  map.value = L.map(mapContainer.value).setView([0, 0], 2)
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {}).addTo(map.value)
+  markersLayer.value = L.layerGroup().addTo(map.value)
+  updateMarkers()
 })
+
+function updateMarkers () {
+  Object.entries(sites).forEach(([site, { lat, lon }]) => {
+    const iconUrl = site === props.highlightedSite
+      ? availableIcon
+      : unavailableIcon
+
+    // This replaces createIcon function
+    L.marker([lat, lon], { icon: L.icon({ iconUrl, iconSize: [30, 42], iconAnchor: [15, 42] }) })
+      .addTo(markersLayer.value)
+  })
+}
+
+// Updates the markers when the selected time from a different site changes
+watch(() => props.highlightedSite, (newSite) => {
+  markersLayer.value.clearLayers()
+  updateMarkers()
+})
+
 </script>
 
 <template>

--- a/src/components/RealTimeInterface/TimePicker.vue
+++ b/src/components/RealTimeInterface/TimePicker.vue
@@ -180,7 +180,7 @@ const blockRti = async () => {
     successCallback: bookDate,
     failCallback: (e) => {
       bookingInProgess.value = false
-      if (e.non_field_errors[0].includes('Not enough realtime')) {
+      if (e.non_field_errors[0]?.includes('Not enough realtime')) {
         errorMessage.value = 'This project does not have any live observing credit. Choose another project.'
       } else {
         errorMessage.value = 'Failed to book session. Please select another time'
@@ -195,37 +195,28 @@ const bookDate = () => {
   }
 }
 
-// Gets the available times for the selected date and sorts them by site and deduplicates times
 const siteTimes = computed(() => {
-  if (!date.value) return {}
+  const dateKey = date.value.toDateString()
+  const slots = availableTimes.value[dateKey] || {}
+  const groupedSiteTimes = {}
 
-  const dateStr = date.value.toDateString()
-  const daySlots = availableTimes.value[dateStr] || {}
-  const grouped = {}
-
-  // Iterates over the available times (dayslots) for the selected date
   // timeKey is the time in ISO format (e.g. Thu Apr 24 2025 21:45:00 GMT-0700 (Pacific Daylight Time))
   // and resources are the telescopes available per site (e.g. {site: 'tfn', enclosure: 'aqwa', telescope: '0m4a'}, {site: 'tfn', enclosure: 'aqwa', telescope: '0m4b'})
-  Object.entries(daySlots).forEach(([timeKey, { resources }]) => {
-    const slot = new Date(timeKey)
-    resources.forEach(({ site }) => {
-      // If the site is not already in the grouped object, create a new Set for it
-      if (!grouped[site]) grouped[site] = new Set()
-      // Adds the timestamp to the Set (automatically deduplicating [some sites have multiple telescopes and therefore more of the same time availability. So say, for example, 2 telescopes are available at 10:00, we only want to show that time once])
-      grouped[site].add(slot.getTime())
-    })
-  })
-
-  // convert sets back into sorted arrays of Date
-  return Object.fromEntries(
-    // Converts the grouped object into an array of entries, where each entry is an array containing the site and an array of times
-    Object.entries(grouped).map(([site, timesSet]) => {
-      const arr = Array.from(timesSet)
-        .map(ms => new Date(ms))
-        .sort((a, b) => a - b)
-      return [site, arr]
-    })
-  )
+  for (const [timeKey, { resources }] of Object.entries(slots)) {
+    const dateTime = new Date(timeKey)
+    for (const { site } of resources) {
+      const arr = groupedSiteTimes[site] ||= []
+      // with `some` we avoid duplicating times. Some sites have multiple telescopes and therefore more of the same time availability. So say, for example, 2 telescopes are available at 10:00, we only want to show that time once
+      if (!arr.some(d => d.getTime() === dateTime.getTime())) {
+        arr.push(dateTime)
+      }
+    }
+  }
+  // sorts in ascending order
+  for (const arr of Object.values(groupedSiteTimes)) {
+    arr.sort((a, b) => a - b)
+  }
+  return groupedSiteTimes
 })
 
 function onTimeClick (site, time) {


### PR DESCRIPTION
## UPDATE: View when booking a real time session

**Background:**
Users would select a date and then a bunch of times would appear. Then after the user selected a time, the map would appear with available sites. Now, sites are presented with times under them as well as the map. When the user clicks on a time under a site, the map updates its marker to green for the selected site (the visual helps you understand better what I'm trying to say).

**Implementation:**
Updated the way times are sorted. 
Also deduplication was important since some sites have more than one telescope and therefore, the same time may be available. 
When the user clicks on a time, props are passed to the map component so that it updates its marker and makes the selected site green.

### VISUALS
https://github.com/user-attachments/assets/d2907db9-db17-40b8-bdc6-92c6ca1325fe

