### PR TITLE
Fix/skymap

### DIFF
--- a/src/components/RealTimeInterface/CelestialMap/SkyChart.vue
+++ b/src/components/RealTimeInterface/CelestialMap/SkyChart.vue
@@ -35,12 +35,8 @@ watch(
 )
 
 function updateLocation () {
-  const time = new Date()
-  time.setHours(time.getHours())
-  // Adjust for timezone so that celestial will display the correct sky map
-  time.setTime(time.getTime() + time.getTimezoneOffset() * 60000)
-  Celestial.date(time)
-  Celestial.location([lat.value, lng.value])
+  const now = new Date().toUTCString()
+  Celestial.skyview({ date: now, location: [lat.value, lng.value] })
   Celestial.resize({ width: 0 })
 }
 

--- a/src/components/RealTimeInterface/TimePicker.vue
+++ b/src/components/RealTimeInterface/TimePicker.vue
@@ -181,7 +181,7 @@ const blockRti = async () => {
     successCallback: bookDate,
     failCallback: (e) => {
       bookingInProgess.value = false
-      if (e.non_field_errors[0]?.includes('Not enough realtime')) {
+      if (e.non_field_errors && e.non_field_errors[0]?.includes('Not enough realtime')) {
         errorMessage.value = 'This project does not have any live observing credit. Choose another project.'
       } else {
         errorMessage.value = 'Failed to book session. Please select another time'

--- a/src/utils/sites.JSON
+++ b/src/utils/sites.JSON
@@ -15,7 +15,7 @@
         "lon": -119.6982
     },
     "abq": {
-        "name": "??",
+        "name": "Albuquerque, New Mexico",
         "lat": 35.0844,
         "lon": -106.6504
     },

--- a/src/utils/telescopeStates.js
+++ b/src/utils/telescopeStates.js
@@ -9,7 +9,7 @@ export const getTelescopeState = async (site, telescope, enclosure) => {
       url: `${configurationStore.observationPortalUrl}telescope_states/?site=${site}&telescope=${telescope}`,
       method: 'GET',
       successCallback: (response) => {
-        const data = response[`${site}.${enclosure}.${telescope}`][0]
+        const data = response && response[`${site}.${enclosure}.${telescope}`][0]
         resolve(data)
       },
       failCallback: (error) => {


### PR DESCRIPTION
## FIX: Sky Map

**Background:** 
The sky map was not rendering the correct sky. I believe this is now fixed. 

**Implementation:**
Changing the time to `const now = new Date().toUTCString()` seems to do the trick. I do need to verify with Edward. Here are two screenshots comparing https://ofrohn.github.io/celestial-demo/location.html to Explore's sky map.

### VISUALS
**Tenerife sky map on Explore**
<img width="1724" alt="Screenshot 2025-05-01 at 11 00 50 AM" src="https://github.com/user-attachments/assets/1141149c-00df-4c8c-b1a8-e5ab17935cb4" />


**Tenerife sky map on celestial-demo**
<img width="1724" alt="Screenshot 2025-05-01 at 11 00 43 AM" src="https://github.com/user-attachments/assets/155ca7ee-52dd-4bed-9bd5-75535c4bfe9c" />
