### PR TITLE
View/obs details

### DIFF
--- a/src/components/Dashboard/UpcomingBookings.vue
+++ b/src/components/Dashboard/UpcomingBookings.vue
@@ -15,6 +15,9 @@ const obsPortalDataStore = useObsPortalDataStore()
 const currentPage = ref(1)
 const sessionsPerPage = 5
 
+const currentRequestPage = ref(1)
+const requestsPerPage = 5
+
 const pendingScheduledRequests = computed(() => obsPortalDataStore.pendingScheduledRequests)
 
 // change to bookings and add an icon to show completion
@@ -39,6 +42,24 @@ const totalPages = computed(() => {
 
 const changePage = (page) => {
   currentPage.value = page
+}
+
+const numberOfRequests = computed(() => {
+  return Object.keys(obsPortalDataStore.pendingScheduledRequests).length
+})
+
+const paginatedRequests = computed(() => {
+  const start = (currentRequestPage.value - 1) * requestsPerPage
+  const end = start + requestsPerPage
+  return Object.values(obsPortalDataStore.pendingScheduledRequests).slice(start, end)
+})
+
+const totalRequestPages = computed(() => {
+  return Math.ceil(numberOfRequests.value / requestsPerPage)
+})
+
+const changeRequestPage = (page) => {
+  currentRequestPage.value = page
 }
 
 const selectSession = (sessionId) => {
@@ -97,14 +118,14 @@ onMounted(async () => {
     <div class="observations upcoming-obs">
         <h3><span v-if="Object.keys(pendingScheduledRequests).length == 0">No </span>Scheduled Requests</h3>
         <div class="table-summary">
-            <div v-for="requestedObservation in pendingScheduledRequests" :key="requestedObservation.id">
+            <div v-for="requestedObservation in paginatedRequests" :key="requestedObservation.id">
               <div v-for="configuration of requestedObservation.configurations" :key="configuration.id">
                 <p class="target-name">{{ configuration.target.name}}</p>
                 <v-btn @click="viewSelectedObsDetails(requestedObservation.id)" class="button" color="indigo">View Observation Details</v-btn>
-                <!-- TO DO: Define progress and get progress from api -->
-                <!-- <div><progress class="progress is-large is-primary" :value="progress" max="100">{{ progress }}%</progress></div> -->
               </div>
             </div>
+            <button v-if="numberOfRequests > 5 && currentRequestPage!=1" @click="changeRequestPage(currentRequestPage - 1)" class="button">previous</button>
+            <button v-if="numberOfRequests > 5 && currentRequestPage!=totalRequestPages" @click="changeRequestPage(currentRequestPage + 1)" class="button">more</button>
         </div>
         <button class="button red-bg" @click="router.push('/schedule')">Schedule Observations</button>
     </div>

--- a/src/components/Dashboard/UpcomingBookings.vue
+++ b/src/components/Dashboard/UpcomingBookings.vue
@@ -15,7 +15,7 @@ const obsPortalDataStore = useObsPortalDataStore()
 const currentPage = ref(1)
 const sessionsPerPage = 5
 
-const pendingScheduledObservations = obsPortalDataStore.pendingScheduledObservations
+const pendingScheduledObservations = computed(() => obsPortalDataStore.pendingScheduledObservations)
 
 // change to bookings and add an icon to show completion
 const sortedSessions = computed(() => {

--- a/src/components/Dashboard/UpcomingBookings.vue
+++ b/src/components/Dashboard/UpcomingBookings.vue
@@ -100,8 +100,9 @@ onMounted(async () => {
             <div v-for="scheduledObs in pendingScheduledObservations" :key="scheduledObs.id">
               <div v-for="configuration in scheduledObs.request.configurations" :key="configuration.id">
                 <p class="target-name" @click="viewSelectedObsDetails(scheduledObs.request.id)">{{ configuration.target.name}}</p>
+                <v-btn @click="viewSelectedObsDetails(scheduledObs.request.id)" class="button" color="indigo">View Observation Details</v-btn>
                 <!-- TO DO: Define progress and get progress from api -->
-                <div><progress class="progress is-large is-primary" :value="progress" max="100">{{ progress }}%</progress></div>
+                <!-- <div><progress class="progress is-large is-primary" :value="progress" max="100">{{ progress }}%</progress></div> -->
               </div>
             </div>
         </div>

--- a/src/components/Dashboard/UpcomingBookings.vue
+++ b/src/components/Dashboard/UpcomingBookings.vue
@@ -15,7 +15,7 @@ const obsPortalDataStore = useObsPortalDataStore()
 const currentPage = ref(1)
 const sessionsPerPage = 5
 
-const pendingScheduledObservations = computed(() => obsPortalDataStore.pendingScheduledObservations)
+const pendingScheduledRequests = computed(() => obsPortalDataStore.pendingScheduledRequests)
 
 // change to bookings and add an icon to show completion
 const sortedSessions = computed(() => {
@@ -75,7 +75,7 @@ async function viewSelectedObsDetails (requestId) {
 
 onMounted(async () => {
   await obsPortalDataStore.fetchUpcomingRealTimeSessions()
-  await obsPortalDataStore.fetchPendingScheduledObservations()
+  await obsPortalDataStore.fetchPendingScheduledRequests()
 })
 
 </script>
@@ -95,9 +95,9 @@ onMounted(async () => {
         <button class="button red-bg" @click="router.push('/book/realtime')"> Book Slot </button>
     </div>
     <div class="observations upcoming-obs">
-        <h3><span v-if="Object.keys(pendingScheduledObservations).length == 0">No </span>Scheduled Requests</h3>
+        <h3><span v-if="Object.keys(pendingScheduledRequests).length == 0">No </span>Scheduled Requests</h3>
         <div class="table-summary">
-            <div v-for="requestedObservation in pendingScheduledObservations" :key="requestedObservation.id">
+            <div v-for="requestedObservation in pendingScheduledRequests" :key="requestedObservation.id">
               <div v-for="configuration of requestedObservation.configurations" :key="configuration.id">
                 <p class="target-name">{{ configuration.target.name}}</p>
                 <v-btn @click="viewSelectedObsDetails(requestedObservation.id)" class="button" color="indigo">View Observation Details</v-btn>

--- a/src/components/Dashboard/UpcomingBookings.vue
+++ b/src/components/Dashboard/UpcomingBookings.vue
@@ -66,6 +66,13 @@ async function deleteSession (sessionId) {
   })
 }
 
+async function viewSelectedObsDetails (requestId) {
+  router.push({
+    name: 'ScheduledObsDetailsView',
+    params: { requestId }
+  })
+}
+
 onMounted(async () => {
   await obsPortalDataStore.fetchUpcomingRealTimeSessions()
   await obsPortalDataStore.fetchPendingScheduledObservations()
@@ -92,7 +99,7 @@ onMounted(async () => {
         <div class="table-summary">
             <div v-for="scheduledObs in pendingScheduledObservations" :key="scheduledObs.id">
               <div v-for="configuration in scheduledObs.request.configurations" :key="configuration.id">
-                {{ configuration.target.name}}
+                <p class="target-name" @click="viewSelectedObsDetails(scheduledObs.request.id)">{{ configuration.target.name}}</p>
                 <!-- TO DO: Define progress and get progress from api -->
                 <div><progress class="progress is-large is-primary" :value="progress" max="100">{{ progress }}%</progress></div>
               </div>
@@ -102,6 +109,9 @@ onMounted(async () => {
     </div>
 </template>
 <style scoped>
+.target-name {
+  cursor: pointer;
+}
 .progress.is-primary{
     --bulma-progress-value-background-color: #A6CE39;
     --bulma-progress-bar-background-color:#262e35;

--- a/src/components/Dashboard/UpcomingBookings.vue
+++ b/src/components/Dashboard/UpcomingBookings.vue
@@ -97,10 +97,10 @@ onMounted(async () => {
     <div class="observations upcoming-obs">
         <h3><span v-if="Object.keys(pendingScheduledObservations).length == 0">No </span>Scheduled Requests</h3>
         <div class="table-summary">
-            <div v-for="scheduledObs in pendingScheduledObservations" :key="scheduledObs.id">
-              <div v-for="configuration in scheduledObs.request.configurations" :key="configuration.id">
-                <p class="target-name" @click="viewSelectedObsDetails(scheduledObs.request.id)">{{ configuration.target.name}}</p>
-                <v-btn @click="viewSelectedObsDetails(scheduledObs.request.id)" class="button" color="indigo">View Observation Details</v-btn>
+            <div v-for="requestedObservation in pendingScheduledObservations" :key="requestedObservation.id">
+              <div v-for="configuration of requestedObservation.configurations" :key="configuration.id">
+                <p class="target-name">{{ configuration.target.name}}</p>
+                <v-btn @click="viewSelectedObsDetails(requestedObservation.id)" class="button" color="indigo">View Observation Details</v-btn>
                 <!-- TO DO: Define progress and get progress from api -->
                 <!-- <div><progress class="progress is-large is-primary" :value="progress" max="100">{{ progress }}%</progress></div> -->
               </div>

--- a/src/components/Scheduling/BeginnerScheduling.vue
+++ b/src/components/Scheduling/BeginnerScheduling.vue
@@ -4,7 +4,6 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import Calendar from './Calendar.vue'
 import SchedulingSettings from './SchedulingSettings.vue'
 import ProposalDropdown from '../Global/ProposalDropdown.vue'
-import { fetchApiCall } from '../../utils/api.js'
 import { useProposalStore } from '../../stores/proposalManagement.js'
 import { calculateSchedulableTargets } from '../../utils/visibility.js'
 import targets from '../../utils/targets.min.json'
@@ -14,7 +13,7 @@ import starClusterIcon from '@/assets/Icons/star-cluster.png'
 import supernovaIcon from '@/assets/Icons/supernova.png'
 import nebulaIcon from '@/assets/Icons/nebula.png'
 
-const emits = defineEmits(['selectionsComplete', 'showButton'])
+const emits = defineEmits(['selectionsComplete', 'showButton', 'clearErrorMessage'])
 const proposalStore = useProposalStore()
 
 const beginner = ref()
@@ -56,6 +55,7 @@ const previousStep = () => {
   loading.value = false
   beginner.value = ''
   exposureSettings.value = []
+  emits('clearErrorMessage')
   // Prevents `Submit my request` button from showing when going back
   emits('showButton', false)
   if (currentStep.value > 1) currentStep.value -= 1

--- a/src/components/Views/DashboardView.vue
+++ b/src/components/Views/DashboardView.vue
@@ -2,10 +2,7 @@
 import MyGallery from '../Images/MyGallery.vue'
 import UpcomingBookings from '../Dashboard/UpcomingBookings.vue'
 import HomeView from './HomeView.vue'
-import { onMounted, ref } from 'vue'
-import { useObsPortalDataStore } from '../../stores/obsPortalData.js'
-
-const obsPortalDataStore = useObsPortalDataStore()
+import { ref } from 'vue'
 
 const homeIsVisible = ref(true)
 
@@ -13,9 +10,6 @@ function closeHomeView () {
   homeIsVisible.value = false
 }
 
-onMounted(async () => {
-  await obsPortalDataStore.fetchPendingScheduledObservations()
-})
 </script>
 
 <template>

--- a/src/components/Views/ScheduledObsDetailsView.vue
+++ b/src/components/Views/ScheduledObsDetailsView.vue
@@ -15,10 +15,6 @@ const observationDetails = computed(() => {
   return obsPortalDataStore.observationDetails.results[0].requests
 })
 
-// const configurations = computed(() => {
-//   return obsPortalDataStore.observationDetails.results[0].requests[0].configurations
-// })
-
 onMounted(async () => {
   const requestId = props.requestId
   await obsPortalDataStore.fetchSelectedObservationDetails(requestId)

--- a/src/components/Views/ScheduledObsDetailsView.vue
+++ b/src/components/Views/ScheduledObsDetailsView.vue
@@ -12,7 +12,7 @@ const props = defineProps({
 const obsPortalDataStore = useObsPortalDataStore()
 
 const observationDetails = computed(() => {
-  if (obsPortalDataStore.observationDetails.results.length === 0) {
+  if (!obsPortalDataStore.observationDetails || !obsPortalDataStore.observationDetails.results) {
     return null
   }
   return obsPortalDataStore.observationDetails.results[0].requests

--- a/src/components/Views/ScheduledObsDetailsView.vue
+++ b/src/components/Views/ScheduledObsDetailsView.vue
@@ -1,0 +1,9 @@
+<script setup>
+import { computed, ref, onMounted, watch } from 'vue'
+import { useObsPortalDataStore } from '../../stores/obsPortalData.js'
+
+</script>
+
+<template>
+    <h1>HELLO</h1>
+</template>

--- a/src/components/Views/ScheduledObsDetailsView.vue
+++ b/src/components/Views/ScheduledObsDetailsView.vue
@@ -1,9 +1,57 @@
 <script setup>
-import { computed, ref, onMounted, watch } from 'vue'
+import { computed, onMounted, defineProps } from 'vue'
 import { useObsPortalDataStore } from '../../stores/obsPortalData.js'
+
+const props = defineProps({
+  requestId: {
+    type: Number,
+    required: true
+  }
+})
+
+const obsPortalDataStore = useObsPortalDataStore()
+
+const observationDetails = computed(() => {
+  return obsPortalDataStore.observationDetails.results[0].requests
+})
+
+// const configurations = computed(() => {
+//   return obsPortalDataStore.observationDetails.results[0].requests[0].configurations
+// })
+
+onMounted(async () => {
+  const requestId = props.requestId
+  await obsPortalDataStore.fetchSelectedObservationDetails(requestId)
+})
 
 </script>
 
 <template>
-    <h1>HELLO</h1>
-</template>
+    <div v-if="observationDetails">
+        <h2>scheduled observation details</h2>
+      <div
+        v-for="(observation) in observationDetails"
+        :key="observation.id">
+        <div
+          v-for="(config) in observation.configurations"
+          :key="config.id">
+          <p>Target: {{ config.target.name }}</p>
+          <div
+            v-for="(exposure, expIndex) in config.instrument_configs"
+            :key="expIndex">
+            <p>Filter: {{ exposure.optical_elements.filter }}</p>
+            <p>Exposure Time: {{ exposure.exposure_time }}s</p>
+            <p>Exposure Count: {{ exposure.exposure_count }}</p>
+          </div>
+        </div>
+      </div>
+      <p>Start Date: {{ observationDetails[0].windows[0].start }}</p>
+      <p>End Date: {{ observationDetails[0].windows[0].end }}</p>
+    </div>
+
+    <div v-else>
+      <div>
+        <h1>No Observation Details Available</h1>
+      </div>
+    </div>
+  </template>

--- a/src/components/Views/ScheduledObsDetailsView.vue
+++ b/src/components/Views/ScheduledObsDetailsView.vue
@@ -12,6 +12,9 @@ const props = defineProps({
 const obsPortalDataStore = useObsPortalDataStore()
 
 const observationDetails = computed(() => {
+  if (obsPortalDataStore.observationDetails.results.length === 0) {
+    return null
+  }
   return obsPortalDataStore.observationDetails.results[0].requests
 })
 

--- a/src/components/Views/ScheduledObsDetailsView.vue
+++ b/src/components/Views/ScheduledObsDetailsView.vue
@@ -15,7 +15,12 @@ const observationDetails = computed(() => {
   if (!obsPortalDataStore.observationDetails || !obsPortalDataStore.observationDetails.results) {
     return null
   }
-  return obsPortalDataStore.observationDetails.results[0].requests
+  else if (obsPortalDataStore.observationDetails && obsPortalDataStore.observationDetails.results.length !== 0 && obsPortalDataStore.observationDetails.results[0].requests.length !== 0) {
+    return obsPortalDataStore.observationDetails.results[0].requests
+  }
+  else {
+    return null
+  }
 })
 
 onMounted(async () => {

--- a/src/components/Views/ScheduledObsDetailsView.vue
+++ b/src/components/Views/ScheduledObsDetailsView.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, onMounted, defineProps } from 'vue'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { useObsPortalDataStore } from '../../stores/obsPortalData.js'
 
 const props = defineProps({
@@ -31,31 +32,40 @@ onMounted(async () => {
 </script>
 
 <template>
+  <section class="section">
+  <div class="container">
     <div v-if="observationDetails">
-        <h2>scheduled observation details</h2>
+        <h1>scheduled observation details</h1>
       <div
         v-for="(observation) in observationDetails"
         :key="observation.id">
         <div
           v-for="(config) in observation.configurations"
           :key="config.id">
-          <p>Target: {{ config.target.name }}</p>
+          <h2>Target: <span class="green">{{ config.target.name }}</span></h2>
+          <h3>This observation is: {{ observation.state }}</h3>
+
+          <h3><font-awesome-icon icon="fa-regular fa-camera-retro" title="Camera" /> Exposures</h3>
           <div
             v-for="(exposure, expIndex) in config.instrument_configs"
             :key="expIndex">
-            <p>Filter: {{ exposure.optical_elements.filter }}</p>
-            <p>Exposure Time: {{ exposure.exposure_time }}s</p>
-            <p>Exposure Count: {{ exposure.exposure_count }}</p>
+            <p> <font-awesome-icon icon="fa-solid fa-sliders" title="sliders" /> {{ exposure.optical_elements.filter }}
+              - {{ exposure.exposure_time }}s <font-awesome-icon icon="fa-solid fa-xmark" title="times" />
+             {{ exposure.exposure_count }}</p>
           </div>
         </div>
       </div>
-      <p>Start Date: {{ observationDetails[0].windows[0].start }}</p>
-      <p>End Date: {{ observationDetails[0].windows[0].end }}</p>
+      <h3><font-awesome-icon icon="fa-solid fa-calendar-days" title="Calendar" /> Date Window</h3>
+      <p><span class="green">{{ observationDetails[0].windows[0].start }}</span> <FontAwesomeIcon icon="fa-regular fa-arrow-right"  />
+      <span class="red">{{ observationDetails[0].windows[0].end }}</span></p>
     </div>
 
     <div v-else>
       <div>
-        <h1>No Observation Details Available</h1>
+        <h1>Problem viewing observation</h1>
+        <p>There are no details available for this observation</p>
       </div>
     </div>
+    </div>
+  </section>
   </template>

--- a/src/components/Views/SchedulingView.vue
+++ b/src/components/Views/SchedulingView.vue
@@ -199,15 +199,22 @@ const resetView = () => {
   <section class="section">
     <div class="container">
     <div v-if="level === 'beginner' && !showScheduled">
-        <BeginnerScheduling @selectionsComplete="handleUserSelections" @showButton="displayButton = $event" />
+        <BeginnerScheduling
+          @selectionsComplete="handleUserSelections"
+          @showButton="displayButton = $event"
+          @clearErrorMessage="errorMessage = ''"
+        />
+        <div v-if="errorMessage && !showScheduled">
+          <p class="error-message">Error: {{ errorMessage }}</p>
+        </div>
         <v-btn color="indigo" @click="resetView"> Restart</v-btn>
         <v-btn v-if="displayButton" :disabled="!enableButton || isSubmitting" color="indigo" @click="sendObservationRequest">Submit my request!</v-btn>
     </div>
 
       <div v-else-if="level === 'advanced' && !showScheduled">
         <AdvancedScheduling
-        @selectionsComplete="handleUserSelections"
-        @updateDisplay="handleDisplay"
+          @selectionsComplete="handleUserSelections"
+          @updateDisplay="handleDisplay"
         />
         <div v-if="errorMessage && !showScheduled">
           <p class="error-message">Error: {{ errorMessage }}</p>

--- a/src/components/Views/SchedulingView.vue
+++ b/src/components/Views/SchedulingView.vue
@@ -92,6 +92,8 @@ const createRequest = (target, exposures, startDate, endDate) => ({
 
 const getProjectName = () => {
   let targetName = ''
+  const today = new Date()
+  const formattedDate = today.toISOString().split('T')[0]
   if (observationData.value.target) {
     targetName = observationData.value.target.name || ''
   } else if (observationData.value.targets && observationData.value.targets.length) {
@@ -106,7 +108,7 @@ const getProjectName = () => {
       : observationData.value.targets[0].dec
     targetName = `${ra}_${dec}`
   }
-  return `${targetName}_${observationData.value.startDate.split('T')[0]}`
+  return `${targetName}_${formattedDate}`
 }
 
 const sendObservationRequest = async () => {
@@ -140,7 +142,7 @@ const sendObservationRequest = async () => {
         // then it's the first target's RA/Dec. The start date is appended in YYYY-MM-DD format to the end of the name
         'name': getProjectName(),
         'proposal': observationData.value.proposal,
-        'ipp_value': 1.05,
+        'ipp_value': 1.0,
         'operator': operatorValue.value,
         'observation_type': 'NORMAL',
         'requests': requestList
@@ -154,9 +156,9 @@ const sendObservationRequest = async () => {
         showScheduled.value = false
         isSubmitting.value = false
         errorMessage.value = error.requests
-          .map(request => request.non_field_errors)
-          .flat()
-          .join(', ')
+        // .map(request => request.non_field_errors)
+        // .flat()
+        // .join(', ')
       }
     })
   }

--- a/src/components/Views/SchedulingView.vue
+++ b/src/components/Views/SchedulingView.vue
@@ -6,6 +6,9 @@ import { fetchApiCall } from '../../utils/api.js'
 import { formatToUTC } from '../../utils/formatTime'
 import DashboardView from './DashboardView.vue'
 import { useRouter } from 'vue-router'
+import { useConfigurationStore } from '../../stores/configuration.js'
+
+const configurationStore = useConfigurationStore()
 
 // TO DO (future): Get level depending on course completion
 const level = ref('')
@@ -130,7 +133,7 @@ const sendObservationRequest = async () => {
     }
 
     await fetchApiCall({
-      url: 'https://observe.lco.global/api/requestgroups/',
+      url: `${configurationStore.observationPortalUrl}requestgroups/`,
       method: 'POST',
       body: {
         // There are a few different scenarios of what the user might select as a target or targets. The name of the project will be the name of the first target (regardless of how many targets there are) or if there isn't a target name,

--- a/src/main.js
+++ b/src/main.js
@@ -6,11 +6,11 @@ import App from './App.vue'
 import vuetify from './plugins/vuetify'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faBook, faStar, faChartLine, faCalendarDays, faGamepad, faChevronRight, faSquare, faThLarge, faGear, faSliders, faClock, faXmark, faPlusCircle, faDownload, faPenRuler, faListCheck, faChevronDown } from '@fortawesome/free-solid-svg-icons'
-import { faTelescope, faLocationDot, faCameraRetro } from '@fortawesome/pro-regular-svg-icons'
+import { faTelescope, faLocationDot, faCameraRetro, faArrowRight } from '@fortawesome/pro-regular-svg-icons'
 import VCalendar from 'v-calendar'
 import 'v-calendar/style.css'
 
-library.add(faBook, faStar, faChartLine, faCalendarDays, faGamepad, faChevronRight, faSquare, faThLarge, faGear, faSliders, faClock, faXmark, faPlusCircle, faDownload, faPenRuler, faTelescope, faLocationDot, faCameraRetro, faListCheck, faChevronDown)
+library.add(faBook, faStar, faChartLine, faCalendarDays, faGamepad, faChevronRight, faSquare, faThLarge, faGear, faSliders, faClock, faXmark, faPlusCircle, faDownload, faPenRuler, faTelescope, faLocationDot, faCameraRetro, faListCheck, faChevronDown, faArrowRight)
 
 require('@/assets/ptr_main.scss')
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -54,9 +54,10 @@ const routes = [
     component: LogIn
   },
   {
-    path: '/observations/:id',
+    path: '/observations/:requestId',
     name: 'ScheduledObsDetailsView',
-    component: ScheduledObsDetailsView
+    component: ScheduledObsDetailsView,
+    props: true
   }
 ]
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,6 +7,7 @@ import Scheduling from '../components/Views/SchedulingView.vue'
 import About from '../components/Views/AboutView.vue'
 import BookRTI from '../components/Views/BookRTIView.vue'
 import LogIn from '../components/LogIn/LogIn.vue'
+import ScheduledObsDetailsView from '../components/Views/ScheduledObsDetailsView.vue'
 
 const routes = [
   {
@@ -51,6 +52,11 @@ const routes = [
     path: '/login',
     name: 'LogIn',
     component: LogIn
+  },
+  {
+    path: '/observations/:id',
+    name: 'ScheduledObsDetailsView',
+    component: ScheduledObsDetailsView
   }
 ]
 

--- a/src/stores/obsPortalData.js
+++ b/src/stores/obsPortalData.js
@@ -44,31 +44,147 @@ export const useObsPortalDataStore = defineStore('obsPortalData', {
     },
     storePendingScheduledObservations (response) {
       // The format of the response is as follows:
-      // [
-      //     {
-      //       "id": 680316844,
-      //       "request": {
-      //           "id": 3784722,
-      //           "state": "PENDING",
-      //           "configurations": [
-      //             {...configuration details...}
-      //           ]
-      //       },
-      //       and other fields
-      //   }
-      // ]
+    //   {
+    //     "count": 7,
+    //     "next": null,
+    //     "previous": null,
+    //     "results": [
+    //         {
+    //             "id": 2240578,
+    //             "submitter": "ccapetillo",
+    //             "proposal": "LCOEPO2014B-010",
+    //             "name": "M109_2025-05-19",
+    //             "observation_type": "NORMAL",
+    //             "operator": "SINGLE",
+    //             "ipp_value": 1,
+    //             "state": "PENDING",
+    //             "created": "2025-05-19T16:27:20.299250Z",
+    //             "modified": "2025-05-19T16:27:20.299261Z",
+    //             "requests": [
+    //                 {
+    //                     "id": 3866319,
+    //                     "observation_note": "",
+    //                     "optimization_type": "TIME",
+    //                     "state": "PENDING",
+    //                     "acceptability_threshold": 90,
+    //                     "configuration_repeats": 1,
+    //                     "extra_params": {},
+    //                     "modified": "2025-05-19T16:27:20.303691Z",
+    //                     "duration": 656,
+    //                     "configurations": [
+    //                         {
+    //                             "id": 12966963,
+    //                             "instrument_type": "0M4-SCICAM-QHY600",
+    //                             "type": "EXPOSE",
+    //                             "repeat_duration": null,
+    //                             "extra_params": {
+    //                                 "sub_expose": false
+    //                             },
+    //                             "priority": 1,
+    //                             "instrument_configs": [
+    //                                 {
+    //                                     "optical_elements": {
+    //                                         "filter": "rp"
+    //                                     },
+    //                                     "mode": "central30x30",
+    //                                     "exposure_time": 180,
+    //                                     "exposure_count": 1,
+    //                                     "rotator_mode": "",
+    //                                     "extra_params": {
+    //                                         "defocus": 0,
+    //                                         "offset_ra": 0,
+    //                                         "offset_dec": 0
+    //                                     },
+    //                                     "rois": []
+    //                                 },
+    //                                 {
+    //                                     "optical_elements": {
+    //                                         "filter": "B"
+    //                                     },
+    //                                     "mode": "central30x30",
+    //                                     "exposure_time": 180,
+    //                                     "exposure_count": 1,
+    //                                     "rotator_mode": "",
+    //                                     "extra_params": {
+    //                                         "defocus": 0,
+    //                                         "offset_ra": 0,
+    //                                         "offset_dec": 0
+    //                                     },
+    //                                     "rois": []
+    //                                 },
+    //                                 {
+    //                                     "optical_elements": {
+    //                                         "filter": "V"
+    //                                     },
+    //                                     "mode": "central30x30",
+    //                                     "exposure_time": 180,
+    //                                     "exposure_count": 1,
+    //                                     "rotator_mode": "",
+    //                                     "extra_params": {
+    //                                         "defocus": 0,
+    //                                         "offset_ra": 0,
+    //                                         "offset_dec": 0
+    //                                     },
+    //                                     "rois": []
+    //                                 }
+    //                             ],
+    //                             "constraints": {
+    //                                 "max_airmass": 1.6,
+    //                                 "min_lunar_distance": 30,
+    //                                 "max_lunar_phase": 1,
+    //                                 "extra_params": {}
+    //                             },
+    //                             "acquisition_config": {
+    //                                 "mode": "OFF",
+    //                                 "extra_params": {}
+    //                             },
+    //                             "guiding_config": {
+    //                                 "optional": true,
+    //                                 "mode": "ON",
+    //                                 "optical_elements": {},
+    //                                 "exposure_time": null,
+    //                                 "extra_params": {}
+    //                             },
+    //                             "target": {
+    //                                 "type": "ICRS",
+    //                                 "name": "M109",
+    //                                 "ra": 179.4,
+    //                                 "dec": 53.37,
+    //                                 "proper_motion_ra": 0,
+    //                                 "proper_motion_dec": 0,
+    //                                 "parallax": 0,
+    //                                 "epoch": 2000,
+    //                                 "hour_angle": null,
+    //                                 "extra_params": {}
+    //                             }
+    //                         }
+    //                     ],
+    //                     "location": {
+    //                         "telescope_class": "0m4"
+    //                     },
+    //                     "windows": [
+    //                         {
+    //                             "start": "2025-05-20T14:00:00Z",
+    //                             "end": "2025-05-27T14:00:00Z"
+    //                         }
+    //                     ]
+    //                 }
+    //             ]
+    //         }
+    //     ]
+    // }
       this.pendingScheduledObservations = {}
-
-      for (const pendingScheduledObservation of response.results) {
+      const results = response.results
+      const requests = results.map((result) => result.requests).flat()
+      for (const pendingScheduledObservation of requests) {
         // Because a scheduled request is ephemeral and its id can change, we store the request id which is stable
         // So the example above would be stored as:
         // {
         //   3784722: {... details of the request ...}
-        this.pendingScheduledObservations[pendingScheduledObservation.request.id] = pendingScheduledObservation
+        this.pendingScheduledObservations[pendingScheduledObservation.id] = pendingScheduledObservation
       }
     },
     async fetchPendingScheduledObservations () {
-      this.pendingScheduledObservations = {}
       const configurationStore = useConfigurationStore()
       const userDataStore = useUserDataStore()
       const username = userDataStore.username
@@ -76,7 +192,7 @@ export const useObsPortalDataStore = defineStore('obsPortalData', {
         // This will only work with NORMAL observations, so TIME_CRITICAL or RAPID_RESPONSE will not show up.
         //  Also only getting ones submitted by the user, which ignores observations on a shared proposal the user has access too.
         // In the future, we have to change the query
-        url: configurationStore.observationPortalUrl + `observations/?observation_type=NORMAL&state=PENDING&user=${username}&created_after=${fifteenDaysAgo}`,
+        url: configurationStore.observationPortalUrl + `requestgroups/?observation_type=NORMAL&state=PENDING&user=${username}&created_after=${fifteenDaysAgo}`,
         method: 'GET',
         successCallback: (response) => {
           this.storePendingScheduledObservations(response)

--- a/src/stores/obsPortalData.js
+++ b/src/stores/obsPortalData.js
@@ -82,6 +82,18 @@ export const useObsPortalDataStore = defineStore('obsPortalData', {
         }
       })
     },
+    async fetchSelectedObservationDetails (requestId) {
+      const configurationStore = useConfigurationStore()
+      const userDataStore = useUserDataStore()
+      const username = userDataStore.username
+      await fetchApiCall({
+        url: configurationStore.observationPortalUrl + `requestgroups/?state=PENDING&user=${username}&request_id=${requestId}`,
+        method: 'GET',
+        successCallback: (response) => {
+          this.observationDetails = response
+        }
+      })
+    },
     async fetchCompletedObservations (page = 1) {
       const configurationStore = useConfigurationStore()
       const userDataStore = useUserDataStore()

--- a/src/stores/obsPortalData.js
+++ b/src/stores/obsPortalData.js
@@ -10,7 +10,7 @@ export const useObsPortalDataStore = defineStore('obsPortalData', {
     return {
       completedObservations: {},
       upcomingRealTimeSessions: {},
-      pendingScheduledObservations: {},
+      pendingScheduledRequests: {},
       observationDetails: {},
       selectedConfiguration: null,
       completedObservationsCount: 0
@@ -42,7 +42,7 @@ export const useObsPortalDataStore = defineStore('obsPortalData', {
         }
       })
     },
-    storePendingScheduledObservations (response) {
+    storePendingScheduledRequests (response) {
       // The format of the response is as follows:
     //   {
     //     "count": 7,
@@ -173,18 +173,18 @@ export const useObsPortalDataStore = defineStore('obsPortalData', {
     //         }
     //     ]
     // }
-      this.pendingScheduledObservations = {}
+      this.pendingScheduledRequests = {}
       const results = response.results
       const requests = results.map((result) => result.requests).flat()
-      for (const pendingScheduledObservation of requests) {
+      for (const pendingScheduledRequest of requests) {
         // Because a scheduled request is ephemeral and its id can change, we store the request id which is stable
         // So the example above would be stored as:
         // {
         //   3784722: {... details of the request ...}
-        this.pendingScheduledObservations[pendingScheduledObservation.id] = pendingScheduledObservation
+        this.pendingScheduledRequests[pendingScheduledRequest.id] = pendingScheduledRequest
       }
     },
-    async fetchPendingScheduledObservations () {
+    async fetchPendingScheduledRequests () {
       const configurationStore = useConfigurationStore()
       const userDataStore = useUserDataStore()
       const username = userDataStore.username
@@ -195,7 +195,7 @@ export const useObsPortalDataStore = defineStore('obsPortalData', {
         url: configurationStore.observationPortalUrl + `requestgroups/?observation_type=NORMAL&state=PENDING&user=${username}&created_after=${fifteenDaysAgo}`,
         method: 'GET',
         successCallback: (response) => {
-          this.storePendingScheduledObservations(response)
+          this.storePendingScheduledRequests(response)
         }
       })
     },

--- a/src/stores/obsPortalData.js
+++ b/src/stores/obsPortalData.js
@@ -68,6 +68,7 @@ export const useObsPortalDataStore = defineStore('obsPortalData', {
       }
     },
     async fetchPendingScheduledObservations () {
+      this.pendingScheduledObservations = {}
       const configurationStore = useConfigurationStore()
       const userDataStore = useUserDataStore()
       const username = userDataStore.username

--- a/src/tests/integration/components/schedulingView.test.js
+++ b/src/tests/integration/components/schedulingView.test.js
@@ -126,7 +126,7 @@ describe('SchedulingView.vue', () => {
       body: {
         name: `Test Target_${YYYYMMDD}`,
         proposal: 'Test Proposal',
-        ipp_value: 1.05,
+        ipp_value: 1.0,
         operator: 'SINGLE',
         observation_type: 'NORMAL',
         requests: mockRequestList

--- a/src/tests/integration/components/schedulingView.test.js
+++ b/src/tests/integration/components/schedulingView.test.js
@@ -121,7 +121,7 @@ describe('SchedulingView.vue', () => {
     await flushPromises()
     const YYYYMMDD = new Date().toISOString().split('T')[0]
     expect(fetchApiCall).toHaveBeenCalledWith({
-      url: 'https://observe.lco.global/api/requestgroups/',
+      url: 'http://mock-api.com/requestgroups/',
       method: 'POST',
       body: {
         name: `Test Target_${YYYYMMDD}`,

--- a/src/tests/unit/utils/obsPortalDataStore.test.js
+++ b/src/tests/unit/utils/obsPortalDataStore.test.js
@@ -51,7 +51,7 @@ describe('Observation Portal Data Store', () => {
 
   it('fetches PENDING NORMAL observation requests', async () => {
     // --- Upcoming NORMAL sessions ---
-    const mockPendingScheduledObservationsResponse = {
+    const mockPendingScheduledRequestsResponse = {
       results: [
         {
           requests: [
@@ -65,14 +65,14 @@ describe('Observation Portal Data Store', () => {
       ]
     }
 
-    // --- Test fetchPendingScheduledObservations ---
+    // --- Test fetchPendingScheduledRequests ---
     fetchApiCall.mockImplementationOnce(({ successCallback }) => {
-      successCallback(mockPendingScheduledObservationsResponse)
+      successCallback(mockPendingScheduledRequestsResponse)
     })
-    await obsPortalDataStore.fetchPendingScheduledObservations()
+    await obsPortalDataStore.fetchPendingScheduledRequests()
     expect(fetchApiCall).toHaveBeenCalledTimes(1)
-    expect(obsPortalDataStore.pendingScheduledObservations).toEqual({
-      456: mockPendingScheduledObservationsResponse.results[0].requests[0]
+    expect(obsPortalDataStore.pendingScheduledRequests).toEqual({
+      456: mockPendingScheduledRequestsResponse.results[0].requests[0]
     })
   })
 

--- a/src/tests/unit/utils/obsPortalDataStore.test.js
+++ b/src/tests/unit/utils/obsPortalDataStore.test.js
@@ -52,15 +52,17 @@ describe('Observation Portal Data Store', () => {
   it('fetches PENDING NORMAL observation requests', async () => {
     // --- Upcoming NORMAL sessions ---
     const mockPendingScheduledObservationsResponse = {
-      results: [{
-        request:
+      results: [
         {
-          id: 456,
-          // start and end are not relevant for PENDING NORMAL observations
-          state: 'PENDING',
-          observation_type: 'NORMAL'
+          requests: [
+            {
+              id: 456,
+              state: 'PENDING',
+              observation_type: 'NORMAL'
+            }
+          ]
         }
-      }]
+      ]
     }
 
     // --- Test fetchPendingScheduledObservations ---
@@ -70,7 +72,7 @@ describe('Observation Portal Data Store', () => {
     await obsPortalDataStore.fetchPendingScheduledObservations()
     expect(fetchApiCall).toHaveBeenCalledTimes(1)
     expect(obsPortalDataStore.pendingScheduledObservations).toEqual({
-      456: mockPendingScheduledObservationsResponse.results[0]
+      456: mockPendingScheduledObservationsResponse.results[0].requests[0]
     })
   })
 


### PR DESCRIPTION
## NEW VIEW: Scheduled observation details
**Background:**
Users could book normal observations and they could see that their observations were requested but couldn't see the observation details once booked. Now they can see the observation details by using the request id.

**Implementation:**
When the user clicks on one of their normal observation requests, the request id is passed as props from the url to the view component. This is then used to make a call to `/requestgroups/request_id=<id>` and get the selected scheduled observations details.


### VISUALS:
**The first Barnard168 and the first CassiopeiaA are individual requests. The other two, (which are the same targets but made a separate request) are made under one single request. When the user's submission has more than one target (the last click), we get both requests even when clicking on the one**

https://github.com/user-attachments/assets/47aca09c-9064-4527-8c41-387fa481546a


