### PR TITLE
Feature/rti progress

### DIFF
--- a/src/components/RealTimeInterface/CelestialMap/SkyChart.vue
+++ b/src/components/RealTimeInterface/CelestialMap/SkyChart.vue
@@ -36,10 +36,6 @@ watch(
 
 function updateLocation () {
   const now = new Date().toUTCString()
-  // time.setHours(time.getHours())
-  // time.setTime(time.getTime() + time.getTimezoneOffset() * 60000)
-  // Celestial.date(now)
-  // Celestial.location([lat.value, lng.value])
   Celestial.skyview({ date: now, location: [lat.value, lng.value] })
   Celestial.resize({ width: 0 })
   Celestial.redraw()
@@ -195,7 +191,6 @@ function initializeCelestial () {
   }
   Celestial.display(config)
   updateLocation()
-  // Celestial.rotate([0, 0, zRotation])
   setTimeout(() => {
     renderCrosshairsAtCenter()
   }, 1000)

--- a/src/components/RealTimeInterface/CelestialMap/SkyChart.vue
+++ b/src/components/RealTimeInterface/CelestialMap/SkyChart.vue
@@ -36,15 +36,22 @@ watch(
 
 function updateLocation () {
   const now = new Date().toUTCString()
+  // time.setHours(time.getHours())
+  // time.setTime(time.getTime() + time.getTimezoneOffset() * 60000)
+  // Celestial.date(now)
+  // Celestial.location([lat.value, lng.value])
   Celestial.skyview({ date: now, location: [lat.value, lng.value] })
   Celestial.resize({ width: 0 })
+  Celestial.redraw()
 }
 
 function initializeCelestial () {
   const config = {
     width: 600,
-    projection: 'stereographic',
+    settimezone: false,
+    projection: 'stereographic', // Projection type, see d3-celestial docs for options
     transform: 'equatorial',
+    // center: [0, 0], // Center of the map in [ra, dec, rotation] format
     controls: false,
     orientationfixed: true,
     follow: 'zenith',
@@ -133,8 +140,8 @@ function initializeCelestial () {
       namesType: 'desig'
     },
     constellations: {
-      show: false,
-      names: false,
+      show: true,
+      names: true,
       namesType: false,
       nameStyle: {
         fill: '#cccc99',
@@ -188,6 +195,7 @@ function initializeCelestial () {
   }
   Celestial.display(config)
   updateLocation()
+  // Celestial.rotate([0, 0, zRotation])
   setTimeout(() => {
     renderCrosshairsAtCenter()
   }, 1000)
@@ -274,7 +282,6 @@ function moveCrosshairsToRaDec (ra, dec) {
   // Clears existing crosshairs
   ctx.clearRect(0, 0, canvas.width, canvas.height)
   Celestial.redraw()
-
   const pixelCoords = Celestial.mapProjection([ra, dec])
 
   if (pixelCoords) {
@@ -328,13 +335,17 @@ onMounted(() => {
   if (currentSession && currentSession.site) {
     const siteInfo = sites[currentSession.site]
     if (siteInfo && Celestial) {
+      initializeCelestial()
       lat.value = siteInfo.lat
       lng.value = siteInfo.lon
-      initializeCelestial()
+      setTimeout(() => {
+        initializeCelestial()
+      }, 2500)
     }
   }
   attachClickListener()
 })
+
 </script>
 
 <template>

--- a/src/components/RealTimeInterface/PolledThumbnails.vue
+++ b/src/components/RealTimeInterface/PolledThumbnails.vue
@@ -23,7 +23,7 @@ const getThumbnails = async () => {
     successCallback: (data) => {
       thumbnails.value = data.results.map(result => result.url)
       if (thumbnails.value.length > 0) {
-        emits('thumbnailsFetched', true)
+        emits('thumbnailsFetched', thumbnails.value.length)
       }
     },
     failCallback: console.error

--- a/src/components/RealTimeInterface/PolledThumbnails.vue
+++ b/src/components/RealTimeInterface/PolledThumbnails.vue
@@ -29,7 +29,9 @@ const getThumbnails = async () => {
     url: configurationStore.thumbnailArchiveUrl + `thumbnails/?observation_id=${sessionId}&size=large`,
     method: 'GET',
     successCallback: (data) => {
-      thumbnails.value = data.results.map(result => result.url)
+      thumbnails.value = data.results
+        .filter(result => result.url.includes('e91-large_thumbnail'))
+        .map(result => result.url)
       if (thumbnails.value.length > 0) {
         emits('thumbnailsFetched', thumbnails.value.length)
       }

--- a/src/components/RealTimeInterface/PolledThumbnails.vue
+++ b/src/components/RealTimeInterface/PolledThumbnails.vue
@@ -16,7 +16,15 @@ const emits = defineEmits(['thumbnailsFetched'])
 const thumbnails = ref([])
 let pollingInterval = null
 
+let demoCounter = 0
 const getThumbnails = async () => {
+  if (configurationStore.demo) {
+    // simulate one new thumbnail every 15s until exposureCount
+    demoCounter = Math.min(demoCounter + 1, realTimeSessionsStore.exposureCount)
+    thumbnails.value = Array(demoCounter).fill('')
+    emits('thumbnailsFetched', demoCounter)
+    return
+  }
   await fetchApiCall({
     url: configurationStore.thumbnailArchiveUrl + `thumbnails/?observation_id=${sessionId}&size=large`,
     method: 'GET',
@@ -32,7 +40,8 @@ const getThumbnails = async () => {
 
 onMounted(() => {
   getThumbnails()
-  pollingInterval = setInterval(getThumbnails, 3000)
+  const intervalMs = configurationStore.demo ? 15000 : 3000
+  pollingInterval = setInterval(getThumbnails, intervalMs)
 })
 
 </script>

--- a/src/components/RealTimeInterface/SessionImageCapture.vue
+++ b/src/components/RealTimeInterface/SessionImageCapture.vue
@@ -24,7 +24,6 @@ let pollingInterval = null
 const anim = ref(null)
 const thumbnailsFetched = ref(false)
 const imagesDone = ref(false)
-const currentThumbnail = computed(() => realTimeSessionsStore.currentThumbnail)
 const exposureCount = computed(() => realTimeSessionsStore.exposureCount)
 
 const emits = defineEmits(['updateRenderGallery'])
@@ -71,6 +70,7 @@ const fetchTelescopeStatus = async () => {
 }
 
 const handleThumbnailsFetched = (count) => {
+  console.log('Thumbnails fetched:', count)
   thumbnailsFetched.value = true
   // Updates store with new count and restarts the progress bar
   realTimeSessionsStore.countThumbnails(count)
@@ -181,7 +181,7 @@ const setSiteState = computed(() => {
               </div>
             </div>
             <div v-if="exposureCount > 1" class="thumbnail-counter">
-              {{ currentThumbnail }} of {{ exposureCount }}
+              {{ realTimeSessionsStore.currentThumbnail }} of {{ exposureCount }}
             </div>
             <div class="progress-container">
               <div

--- a/src/components/RealTimeInterface/SessionImageCapture.vue
+++ b/src/components/RealTimeInterface/SessionImageCapture.vue
@@ -35,45 +35,6 @@ const failedToCaptureImages = computed(() => {
   return status.value.status === 'Unknown'
 })
 
-// const fetchTimeRemaining = async () => {
-//   const token = realTimeSessionsStore.getTokenForCurrentSession
-//   const headers = {
-//     'Content-Type': 'application/json',
-//     'Accept': 'application/json',
-//     'Authorization': `${token}`
-//   }
-//   const cleanedExpTime = props.exposureSettings.map(Number)
-//   const payload = { expTime: cleanedExpTime }
-
-//   // I believe I also have to send the body of the request, not sure
-//   await fetchApiCall({
-//     url: configurationStore.rtiBridgeUrl + 'observation-params',
-//     method: 'POST',
-//     header: headers,
-//     body: payload,
-//     successCallback: (response) => {
-//       const seconds = response.observation_params.observation_length
-//       realTimeSessionsStore.updateRequestedExposureTime(seconds)
-//       timeRemaining.value = seconds
-//       totalObservationTime.value = seconds
-//       lastUpdatedAt.value = Date.now()
-//     }
-//   })
-// }
-// const now = ref(Date.now())
-
-// const progressPercent = computed(() => {
-//   const total = totalObservationTime.value
-//   if (!total || !lastUpdatedAt.value) return 0
-
-//   const elapsed = (now.value - lastUpdatedAt.value) / 1000
-//   return Math.min((elapsed / total) * 100, 100)
-// })
-
-// ^^^ this returns 'observation_length'. we should make a request every 5 seconds and update the time remaining
-// the progress bar should have a gradual increase and check every 5 seconds
-// render % of the progress bar --> total time - current time / total time??? check the math
-
 const fetchTelescopeStatus = async () => {
   if (configurationStore.demo) {
     status.value = {

--- a/src/components/RealTimeInterface/SessionImageCapture.vue
+++ b/src/components/RealTimeInterface/SessionImageCapture.vue
@@ -10,8 +10,8 @@ import BlocksJSON from '@/assets/progress-blocks-bodymovin.json'
 import GalaxyJSON from '@/assets/galaxy_loading_pixels.json'
 
 const props = defineProps({
-  exposureCount: {
-    type: Number,
+  exposureSettings: {
+    type: Array,
     required: true
   }
 })
@@ -35,23 +35,20 @@ const failedToCaptureImages = computed(() => {
 })
 
 const fetchTimeRemaining = async () => {
-  console.log('props.exposureCount', props.exposureCount)
   const token = realTimeSessionsStore.getTokenForCurrentSession
   const headers = {
     'Content-Type': 'application/json',
     'Accept': 'application/json',
     'Authorization': `${token}`
   }
-  const requestBody = {
-    'expTime': props.exposureCount
-  }
+  const payload = { expTime: props.exposureSettings }
 
   // I believe I also have to send the body of the request, not sure
   await fetchApiCall({
     url: configurationStore.rtiBridgeUrl + 'observation-params',
     method: 'POST',
     header: headers,
-    body: requestBody,
+    body: JSON.stringify(payload),
     successCallback: (response) => {
       const timeRemaining = response
       // this is where we would update the progress bar
@@ -82,9 +79,6 @@ const fetchTelescopeStatus = async () => {
     'Content-Type': 'application/json',
     'Accept': 'application/json',
     'Authorization': `${token}`
-  }
-  const requestBody = {
-    'expTime': [30]
   }
   await fetchApiCall({
     url: configurationStore.rtiBridgeUrl + 'status',

--- a/src/components/RealTimeInterface/SessionImageCapture.vue
+++ b/src/components/RealTimeInterface/SessionImageCapture.vue
@@ -107,10 +107,12 @@ const fetchTelescopeStatus = async () => {
   })
 }
 
-const handleThumbnailsFetched = (fetched) => {
-  if (fetched) {
-    thumbnailsFetched.value = true
-  }
+const handleThumbnailsFetched = (count) => {
+  thumbnailsFetched.value = true
+  // Updates store with new count and restarts the progress bar
+  realTimeSessionsStore.countThumbnails(count)
+  realTimeSessionsStore.resetProgress()
+  realTimeSessionsStore.initializeProgressTicker()
 }
 
 const goBackToSessionStarted = () => {
@@ -215,6 +217,9 @@ const setSiteState = computed(() => {
                     </div>
                 </div>
               </div>
+            </div>
+            <div v-if="realTimeSessionsStore.exposureCount > 1" class="thumbnail-counter">
+              {{ realTimeSessionsStore.currentThumbnail }} of {{ realTimeSessionsStore.exposureCount }}
             </div>
             <div class="progress-container">
               <div

--- a/src/components/RealTimeInterface/SessionImageCapture.vue
+++ b/src/components/RealTimeInterface/SessionImageCapture.vue
@@ -70,7 +70,6 @@ const fetchTelescopeStatus = async () => {
 }
 
 const handleThumbnailsFetched = (count) => {
-  console.log('Thumbnails fetched:', count)
   thumbnailsFetched.value = true
   // Updates store with new count and restarts the progress bar
   realTimeSessionsStore.countThumbnails(count)

--- a/src/components/RealTimeInterface/SessionImageCapture.vue
+++ b/src/components/RealTimeInterface/SessionImageCapture.vue
@@ -24,6 +24,8 @@ let pollingInterval = null
 const anim = ref(null)
 const thumbnailsFetched = ref(false)
 const imagesDone = ref(false)
+const currentThumbnail = computed(() => realTimeSessionsStore.currentThumbnail)
+const exposureCount = computed(() => realTimeSessionsStore.exposureCount)
 
 const emits = defineEmits(['updateRenderGallery'])
 
@@ -72,7 +74,6 @@ const handleThumbnailsFetched = (count) => {
   thumbnailsFetched.value = true
   // Updates store with new count and restarts the progress bar
   realTimeSessionsStore.countThumbnails(count)
-  realTimeSessionsStore.resetProgress()
   realTimeSessionsStore.initializeProgressTicker()
 }
 
@@ -179,8 +180,8 @@ const setSiteState = computed(() => {
                 </div>
               </div>
             </div>
-            <div v-if="realTimeSessionsStore.exposureCount > 1" class="thumbnail-counter">
-              {{ realTimeSessionsStore.currentThumbnail }} of {{ realTimeSessionsStore.exposureCount }}
+            <div v-if="exposureCount > 1" class="thumbnail-counter">
+              {{ currentThumbnail }} of {{ exposureCount }}
             </div>
             <div class="progress-container">
               <div

--- a/src/components/RealTimeInterface/SessionImageCapture.vue
+++ b/src/components/RealTimeInterface/SessionImageCapture.vue
@@ -141,7 +141,7 @@ onMounted(() => {
   fetchTelescopeStatus()
   pollingInterval = setInterval(fetchTelescopeStatus, 1000)
   anim.value.goToAndPlay(0, true)
-  realTimeSessionsStore.fetchObservationParams(props.exposureSettings)
+  realTimeSessionsStore.initializeProgressTicker()
 })
 
 onUnmounted(() => {

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -159,6 +159,7 @@ const resetValues = () => {
 }
 
 const sendGoCommand = async () => {
+  realTimeSessionsStore.resetProgress()
   loading.value = true
   exposureError.value = ''
   isExposureTimeValid.value = true

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -162,6 +162,7 @@ const sendGoCommand = async () => {
   loading.value = true
   exposureError.value = ''
   isExposureTimeValid.value = true
+  realTimeSessionsStore.thumbnailCount = 0
   const token = realTimeSessionsStore.getTokenForCurrentSession
   const headers = {
     'Content-Type': 'application/json',

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -154,6 +154,7 @@ const resetValues = () => {
   selectedFilter.value = ''
   fieldOfView.value = 1.0
   loading.value = false
+  realTimeSessionsStore.resetProgress()
 }
 
 const sendGoCommand = async () => {

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -260,7 +260,7 @@ const incompleteSelection = computed(() => {
   return exposureTime.value === '' || exposureCount.value === '' || selectedFilter.value === '' || isExposureTimeValid.value === false
 })
 
-watch(exposureTime, (newTime) => {
+watch(exposureTime, () => {
   isExposureTimeValid.value = true
   exposureError.value = ''
 })
@@ -269,7 +269,7 @@ const targetNameEntered = computed(() => {
   return skyCoordinatesStore.targetNameEntered
 })
 
-watch(targetNameEntered, (newValue, oldValue) => {
+watch(targetNameEntered, () => {
   if (targetNameEntered.value === '') {
     targeterror.value = false
     targeterrorMsg.value = ''

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -175,6 +175,7 @@ const sendGoCommand = async () => {
     exposFilter = ['rp', 'V', 'B']
     exposTime = [Number(exposureTime.value), Number(exposureTime.value), Number(exposureTime.value)]
     exposureSettings.value = exposTime
+    realTimeSessionsStore.exposureCount = exposTime.length
   } else {
   // If suggestions mode is selected, then selectedFilter and exposureTime are populated with the values from the selected target
   // If manual mode is selected, then selectedFilter and exposureTime are populated with the values entered by the user
@@ -182,6 +183,7 @@ const sendGoCommand = async () => {
     exposFilter = suggestionOrManual.value === 'suggestions' ? selectedFilter.value : Array(exposureCount.value).fill(selectedFilter.value)
     exposTime = suggestionOrManual.value === 'suggestions' ? exposureTime.value : Array(exposureCount.value).fill(Number(exposureTime.value))
     exposureSettings.value = exposTime
+    realTimeSessionsStore.exposureCount = exposTime.length
   }
   const requestBody = {
     dec: Number(dec.value),

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -155,6 +155,7 @@ const resetValues = () => {
   fieldOfView.value = 1.0
   loading.value = false
   realTimeSessionsStore.resetProgress()
+  realTimeSessionsStore.fetchObservationParams(exposureSettings.value)
 }
 
 const sendGoCommand = async () => {

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -50,6 +50,7 @@ const validTarget = ref(false)
 const isRaFocused = ref(false)
 const isDecFocused = ref(false)
 const maxExposures = ref(3)
+const exposureSettings = ref([])
 
 const currentSession = realTimeSessionsStore.currentSession
 const siteInfo = sites[currentSession.site]
@@ -171,12 +172,14 @@ const sendGoCommand = async () => {
   if (selectedFilter.value === 'rgb' && suggestionOrManual.value === 'manual') {
     exposFilter = ['rp', 'V', 'B']
     exposTime = [Number(exposureTime.value), Number(exposureTime.value), Number(exposureTime.value)]
+    exposureSettings.value = exposTime
   } else {
   // If suggestions mode is selected, then selectedFilter and exposureTime are populated with the values from the selected target
   // If manual mode is selected, then selectedFilter and exposureTime are populated with the values entered by the user
   // The fill method is used to repeat the values for each exposure in the sequence as many times as the value of exposureCount
     exposFilter = suggestionOrManual.value === 'suggestions' ? selectedFilter.value : Array(exposureCount.value).fill(selectedFilter.value)
     exposTime = suggestionOrManual.value === 'suggestions' ? exposureTime.value : Array(exposureCount.value).fill(Number(exposureTime.value))
+    exposureSettings.value = exposTime
   }
   const requestBody = {
     dec: Number(dec.value),
@@ -501,7 +504,7 @@ watch(
     </div>
   </div>
   <div v-else-if="isCapturingImages">
-    <SessionImageCapture @updateRenderGallery="updateRenderGallery" :ra="ra" :dec="dec" :exposure-count="exposureCount" :selected-filter="selectedFilter" :exposure-time="exposureTime" :target-name="targetName" :field-of-view="fieldOfView"/>
+    <SessionImageCapture @updateRenderGallery="updateRenderGallery" :ra="ra" :dec="dec" :exposure-count="exposureCount" :exposure-time="exposureTime" :exposure-settings="exposureSettings" :selected-filter="selectedFilter" :target-name="targetName" :field-of-view="fieldOfView"/>
   </div>
 </template>
 

--- a/src/components/RealTimeInterface/SessionStarted.vue
+++ b/src/components/RealTimeInterface/SessionStarted.vue
@@ -283,6 +283,10 @@ onMounted(async () => {
   filterList.value.unshift({ name: 'RGB', code: 'rgb' })
   getVisibleTargets()
   skyCoordinatesStore.clearCoordinates()
+  // TO DO: fetch telescope status every 5 seconds if it's available. If it's not available, fetch every second.
+  // also if not available, render a different view
+  //
+  await realTimeSessionsStore.fetchTelescopeStatus()
 })
 
 function handleUpdateCoordinates ({ ra: newRa, dec: newDec }) {

--- a/src/components/Views/RealTimeInterfaceView.vue
+++ b/src/components/Views/RealTimeInterfaceView.vue
@@ -21,37 +21,32 @@ const telescope = computed(() => telname[selectedSession.telescope])
 const availability = computed(() => realTimeSessionsStore.telescopeAvailability.event_type)
 const reason = computed(() => realTimeSessionsStore.telescopeAvailability.event_reason)
 
-const telescopeStatus = computed(() => { return realTimeSessionsStore.telescopeStatus })
-const availabilityStatus = computed(() => { return telescopeStatus.value.status.availability })
 // this is going to be used to conditionally render
 const isTelescopeAvailable = computed(() => {
   return realTimeSessionsStore.isTelescopeAvailable
 })
 
 const availabilityReason = computed(() => {
-  const reason = availabilityStatus.value
-  switch (reason) {
-    case 'Sun up':
-      return 'Telescope is currently closed because the Sun is up'
-    case 'Unavailable for technical reasons':
-      return 'Telescope is unavailable for technical reasons'
-    case 'Closed for bad weather':
-      return 'Telescope is currently closed for bad weather'
-    case 'Closed for maintenance':
-      return 'Telescope is temporarily closed for maintenance'
-    default:
-      // Available is default
-      return reason
+  let message
+  if (reason.value === 'Available' || !reason.value) {
+    message = 'Telescope is available for observation'
+  } else {
+    // Replace underscores with spaces and capitalize first letter
+    const formattedReason = reason.value
+      ? reason.value.replace(/_/g, ' ').replace(/^\w/, c => c.toUpperCase())
+      : ''
+    message = `Telescope is currently closed for the following reason: ${formattedReason}`
   }
+  return message
 })
 
-watch(() => availabilityStatus.value, () => {
-  if (availabilityStatus.value !== 'Available') {
-    realTimeSessionsStore.isTelescopeAvailable = false
-  } else if (availabilityStatus.value === 'Available') {
-    realTimeSessionsStore.isTelescopeAvailable = true
-  }
-})
+// watch(() => availabilityStatus.value, () => {
+//   if (availabilityStatus.value !== 'Available') {
+//     realTimeSessionsStore.isTelescopeAvailable = false
+//   } else if (availabilityStatus.value === 'Available') {
+//     realTimeSessionsStore.isTelescopeAvailable = true
+//   }
+// })
 
 const statusNotExpired = computed(() => {
   return realTimeSessionsStore.currentStatus === 'ACTIVE' || realTimeSessionsStore.currentStatus === 'UNEXPIRED' || realTimeSessionsStore.currentStatus === 'INACTIVE'

--- a/src/components/Views/RealTimeInterfaceView.vue
+++ b/src/components/Views/RealTimeInterfaceView.vue
@@ -21,11 +21,6 @@ const telescope = computed(() => telname[selectedSession.telescope])
 const availability = computed(() => realTimeSessionsStore.telescopeAvailability.event_type)
 const reason = computed(() => realTimeSessionsStore.telescopeAvailability.event_reason)
 
-// this is going to be used to conditionally render
-const isTelescopeAvailable = computed(() => {
-  return realTimeSessionsStore.isTelescopeAvailable
-})
-
 const availabilityReason = computed(() => {
   let message
   if (reason.value === 'Available' || !reason.value) {
@@ -113,7 +108,7 @@ onMounted(async () => {
   <template v-if="loading">
     <v-progress-circular indeterminate color="white" model-value="20" class="loading"/>
   </template>
-  <template v-else-if="!isTelescopeAvailable && realTimeSessionsStore.currentStatus === 'ACTIVE'">
+  <template v-else-if="!realTimeSessionsStore.isTelescopeAvailable && realTimeSessionsStore.currentStatus === 'ACTIVE'">
     <section>
       <div class="container">
         <div class="content">

--- a/src/components/Views/RealTimeInterfaceView.vue
+++ b/src/components/Views/RealTimeInterfaceView.vue
@@ -40,14 +40,6 @@ const availabilityReason = computed(() => {
   return message
 })
 
-// watch(() => availabilityStatus.value, () => {
-//   if (availabilityStatus.value !== 'Available') {
-//     realTimeSessionsStore.isTelescopeAvailable = false
-//   } else if (availabilityStatus.value === 'Available') {
-//     realTimeSessionsStore.isTelescopeAvailable = true
-//   }
-// })
-
 const statusNotExpired = computed(() => {
   return realTimeSessionsStore.currentStatus === 'ACTIVE' || realTimeSessionsStore.currentStatus === 'UNEXPIRED' || realTimeSessionsStore.currentStatus === 'INACTIVE'
 })

--- a/src/components/Views/SchedulingView.vue
+++ b/src/components/Views/SchedulingView.vue
@@ -155,7 +155,9 @@ const sendObservationRequest = async () => {
       failCallback: (error) => {
         showScheduled.value = false
         isSubmitting.value = false
-        errorMessage.value = error.requests
+        for (const errorMssg of error.requests) {
+          errorMessage.value = errorMssg.non_field_errors[0]
+        }
         // .map(request => request.non_field_errors)
         // .flat()
         // .join(', ')

--- a/src/stores/realTimeSessions.js
+++ b/src/stores/realTimeSessions.js
@@ -18,7 +18,10 @@ export const useRealTimeSessionsStore = defineStore('realTimeSessions', {
       observationTotalTime: 0,
       observationStartedAt: 0,
       observationNow: Date.now(),
-      observationTicker: null
+      observationTicker: null,
+      exposureCount: 0,
+      thumbnailCount: 0,
+      currentThumbnail: 0
     }
   },
   persist: true,
@@ -142,6 +145,9 @@ export const useRealTimeSessionsStore = defineStore('realTimeSessions', {
       this.observationTotalTime = 0
       this.observationStartedAt = 0
       this.observationNow = Date.now()
+    },
+    countThumbnails (count) {
+      this.thumbnailCount = count
     }
   }
 })

--- a/src/stores/realTimeSessions.js
+++ b/src/stores/realTimeSessions.js
@@ -149,6 +149,8 @@ export const useRealTimeSessionsStore = defineStore('realTimeSessions', {
       this.observationTotalTime = 0
       this.observationStartedAt = 0
       this.observationNow = Date.now()
+      this.thumbnailCount = 0
+      this.currentThumbnail = 0
     },
     initializeProgressTicker () {
       // If already running or nothing to track, bail

--- a/src/stores/realTimeSessions.js
+++ b/src/stores/realTimeSessions.js
@@ -44,9 +44,6 @@ export const useRealTimeSessionsStore = defineStore('realTimeSessions', {
     telescopeAvailability (state) {
       return state.telescopeState
     },
-    getObservationTotalTime (state) {
-      return state.observationTotalTime
-    },
     progressPercent (state) {
       const total = state.observationTotalTime
       const elapsed = (state.observationNow - state.observationStartedAt) / 1000

--- a/src/stores/realTimeSessions.js
+++ b/src/stores/realTimeSessions.js
@@ -146,6 +146,16 @@ export const useRealTimeSessionsStore = defineStore('realTimeSessions', {
       this.observationStartedAt = 0
       this.observationNow = Date.now()
     },
+    initializeProgressTicker () {
+      // If already running or nothing to track, bail
+      if (this.observationTicker || this.observationTotalTime === 0 || this.observationStartedAt === 0) {
+        return
+      }
+      // Start ticking
+      this.observationTicker = setInterval(() => {
+        this.observationNow = Date.now()
+      }, 1000)
+    },
     countThumbnails (count) {
       this.thumbnailCount = count
     }

--- a/src/stores/realTimeSessions.js
+++ b/src/stores/realTimeSessions.js
@@ -15,6 +15,8 @@ export const useRealTimeSessionsStore = defineStore('realTimeSessions', {
       sessionTokens: {},
       isCapturingImagesMap: {},
       telescopeState: {},
+      telescopeStatus: {},
+      isTelescopeAvailable: true,
       observationTotalTime: 0,
       observationStartedAt: 0,
       observationNow: Date.now(),
@@ -163,6 +165,7 @@ export const useRealTimeSessionsStore = defineStore('realTimeSessions', {
     },
     countThumbnails (count) {
       this.thumbnailCount = count
+      this.currentThumbnail = count
     },
     async fetchTelescopeStatus () {
       const configurationStore = useConfigurationStore()
@@ -172,19 +175,17 @@ export const useRealTimeSessionsStore = defineStore('realTimeSessions', {
         'Accept': 'application/json',
         'Authorization': `${token}`
       }
-      const response = await fetchApiCall({
+      await fetchApiCall({
         url: configurationStore.rtiBridgeUrl + 'status',
         method: 'GET',
         header: headers,
-        successCallback: (telState) => {
-          console.log('Telescope state:', telState)
-          this.telescopeState = telState
+        successCallback: (telStatus) => {
+          this.telescopeStatus = telStatus
         },
         failCallback: (error) => {
           console.error('Error fetching telescope status:', error)
         }
       })
-      console.log('response:', response)
     }
   }
 })

--- a/src/stores/realTimeSessions.js
+++ b/src/stores/realTimeSessions.js
@@ -163,6 +163,28 @@ export const useRealTimeSessionsStore = defineStore('realTimeSessions', {
     },
     countThumbnails (count) {
       this.thumbnailCount = count
+    },
+    async fetchTelescopeStatus () {
+      const configurationStore = useConfigurationStore()
+      const token = this.getTokenForCurrentSession
+      const headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'Authorization': `${token}`
+      }
+      const response = await fetchApiCall({
+        url: configurationStore.rtiBridgeUrl + 'status',
+        method: 'GET',
+        header: headers,
+        successCallback: (telState) => {
+          console.log('Telescope state:', telState)
+          this.telescopeState = telState
+        },
+        failCallback: (error) => {
+          console.error('Error fetching telescope status:', error)
+        }
+      })
+      console.log('response:', response)
     }
   }
 })

--- a/src/stores/realTimeSessions.js
+++ b/src/stores/realTimeSessions.js
@@ -74,7 +74,7 @@ export const useRealTimeSessionsStore = defineStore('realTimeSessions', {
       }
 
       const response = await fetchApiCall({
-        url: configurationStore.rtiBridgeUrl + 'sessionstatus',
+        url: configurationStore.rtiBridgeUrl + 'session_status',
         method: 'GET',
         header: { Authorization: `Token ${token}` }
       })

--- a/src/utils/telescopeStates.js
+++ b/src/utils/telescopeStates.js
@@ -6,15 +6,17 @@ export const getTelescopeState = async (site, telescope, enclosure) => {
   // This needs to be wrapped in a promise to ensure that the data (which is async) is returned and handled in the realTimeSessions store
   return new Promise((resolve, reject) => {
     fetchApiCall({
-      url: `${configurationStore.observationPortalUrl}telescope_states/?site=${site}&telescope=${telescope}`,
+      url: `${configurationStore.observationPortalUrl}telescope_states/?site=${site}&telescope=${telescope}&enclosure=${enclosure}`,
       method: 'GET',
       successCallback: (response) => {
-        const data = response && response[`${site}.${enclosure}.${telescope}`][0]
+        let data
+        if (!response || !response[`${site}.${enclosure}.${telescope}`]) {
+          // Sometimes there is no response or the response is empty. In this case, we want the user to keep going with their rti session
+          data = 'Reason unavailable'
+        } else {
+          data = response && response[`${site}.${enclosure}.${telescope}`][0]
+        }
         resolve(data)
-      },
-      failCallback: (error) => {
-        console.error('Error fetching telescope state:', error)
-        reject(error)
       }
     })
   })


### PR DESCRIPTION
## FEATURE AND FIX: More informative real time sessions & fix sky map

**Background**
To make real time sessions more informative, I needed to implement the following
1. Get telescope telemetry before and during real time session (before sending the go command to the bridge) so that if telescope is unavailable, users cannot make a request 
2. Get the exposure time requested by the user from the bridge to render a progress bar while users wait for their thumbnails to arrive 

And fixes the sky map(hopefully once and for all) 

### VISUALS
**Telescope unavailable --> not able to make send a go command**
<img width="1606" alt="Screenshot 2025-06-03 at 3 13 00 PM" src="https://github.com/user-attachments/assets/8092a165-8d45-4278-8a2e-9ae8e9e4d47f" />

**Screen recording was recorded before this implementation ^**

https://github.com/user-attachments/assets/b305f716-48b1-4dba-afa6-16a478e4ccb9






