### PR TITLE
Fix/formatcountdown

### DIFF
--- a/src/tests/unit/utils/formatTime.test.js
+++ b/src/tests/unit/utils/formatTime.test.js
@@ -58,15 +58,15 @@ describe('formatUtils.js', () => {
     })
 
     it('formats seconds into hours', () => {
-      expect(formatCountdown(3600 * 3)).toBe('3 hours')
+      expect(formatCountdown(3600 * 3)).toBe('03 hours and 00 minutes')
     })
 
     it('formats seconds into hours and minutes', () => {
-      expect(formatCountdown(5400)).toBe('1h 30m')
+      expect(formatCountdown(5400)).toBe('01 hour and 30 minutes')
     })
 
     it('formats seconds into minutes and seconds', () => {
-      expect(formatCountdown(90)).toBe('01:30')
+      expect(formatCountdown(90)).toBe('01 minute and 30 seconds')
     })
   })
 

--- a/src/utils/formatTime.js
+++ b/src/utils/formatTime.js
@@ -28,11 +28,11 @@ function formatCountdown (seconds) {
   } else if (seconds >= secondsInHour) {
     const hours = Math.floor(seconds / secondsInHour)
     const minutes = Math.floor((seconds % secondsInHour) / secondsInMinute)
-    return `${String(hours).padStart(2, '0')} hours and ${String(minutes).padStart(2, '0')} minutes`
+    return `${String(hours).padStart(2, '0')} hour${hours === 1 ? '' : 's'} and ${String(minutes).padStart(2, '0')} minute${minutes === 1 ? '' : 's'}`
   } else {
     const minutes = Math.floor(seconds / secondsInMinute)
     const secs = seconds % secondsInMinute
-    return `${String(minutes).padStart(2, '0')} minutes and ${String(secs).padStart(2, '0')} seconds`
+    return `${String(minutes).padStart(2, '0')} minute${minutes === 1 ? '' : 's'} and ${String(secs).padStart(2, '0')} second${secs === 1 ? '' : 's'}`
   }
 }
 


### PR DESCRIPTION
## QUICK FIX: Format countdown

Corrected the way the countdown for your real time session are displayed. There was a time that Rachel showed me where her session was in 1 hour and 45 minutes (something along those lines) and it displayed as 2 hours. So now I have updated the format to show, if less than 24 hours, HH:MM. If less than 1 hour, MM:SS. If more than 24 hours, DAYS