### PR TITLE
fix gcr.io/kpt-fn image refs

### DIFF
--- a/k8s/base/deploy-frontend/Kptfile
+++ b/k8s/base/deploy-frontend/Kptfile
@@ -20,6 +20,6 @@ upstreamLock:
     commit: ddad41bfb8f928aa4367d86e7da6677200fe4f26
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-replacements:v0.1.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/apply-replacements:v0.1.1
       configPath: ./fn-replacements.yaml
       name: apply-replacements

--- a/k8s/base/svc-frontend/Kptfile
+++ b/k8s/base/svc-frontend/Kptfile
@@ -20,6 +20,6 @@ upstreamLock:
     commit: c58213d7a52130c977fdff0a51f4bd4fb5ca73a3
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-replacements:v0.1.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/apply-replacements:v0.1.1
       configPath: ./fn-replacements.yaml
       name: apply-replacements

--- a/k8s/envs/local/ns/Kptfile
+++ b/k8s/envs/local/ns/Kptfile
@@ -20,6 +20,6 @@ upstreamLock:
     commit: ddad41bfb8f928aa4367d86e7da6677200fe4f26
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/apply-replacements:v0.1.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/apply-replacements:v0.1.1
       configPath: ./fn-replacements.yaml
       name: apply-replacements


### PR DESCRIPTION
Updates:

### Regex[pattern=image:\s+(gcr\.io\/kpt-fn\/).+,file=**/Kptfile]
Update **/Kptfile
Updating file(s) `**/Kptfile` using pattern `image:\s+(gcr\.io\/kpt-fn\/).+`

### Regex[pattern=image:\s+(gcr\.io\/kpt-fn\/).+,file=**/*.yaml]
Update **/*.yaml
Updating file(s) `**/*.yaml` using pattern `image:\s+(gcr\.io\/kpt-fn\/).+`